### PR TITLE
Removes the ability to add notebook headers from the conf.py file. 

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -4,7 +4,6 @@ from .builders.jupyter import JupyterBuilder
 def setup(app):
     app.add_builder(JupyterBuilder)
     app.add_config_value("jupyter_kernels", None, "jupyter")
-    app.add_config_value("jupyter_headers", None, "jupyter")
     app.add_config_value("jupyter_conversion_mode", None, "jupyter")
     app.add_config_value("jupyter_write_metadata", True, "jupyter")
     app.add_config_value("jupyter_static_file_path", [], "jupyter")

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -21,8 +21,6 @@ class JupyterBuilder(Builder):
     _writer_class = JupyterWriter
 
     def init(self):
-        self.config['jupyter_python_autosave'] = False
-
         # If the user has overridden anything on the command line, set these things which have been overridden.
         instructions = []
         overrides = self.config['jupyter_options']
@@ -33,8 +31,6 @@ class JupyterBuilder(Builder):
             if instruction:
                 if instruction == 'code_only':
                     self.config["jupyter_conversion_mode"] = "code"
-                elif instruction == 'autosave_on':
-                    self.config['jupyter_python_autosave'] = True
                 else:
                     # Fail on unrecognised command.
                     self.warn("Unrecognise command line parameter " + instruction + ", ignoring.")

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -35,7 +35,6 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
 
         # Variables defined in conf.py
         self.jupyter_kernels = builder.config["jupyter_kernels"]
-        self.jupyter_headers = builder.config["jupyter_headers"]
         self.jupyter_write_metadata = builder.config["jupyter_write_metadata"]
 
         # Welcome message block
@@ -115,20 +114,6 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
                 "Highlighting language is not given in .rst file. "
                 "Set kernel as default(python3)")
             self.lang = self.default_lang
-
-        # Header(insert after metadata)
-        if self.jupyter_headers is not None:
-            try:
-                for h in self.jupyter_headers[self.lang][::-1]:
-                    if self.jupyter_write_metadata:
-                        self.output["cells"].insert(1, h)
-                    else:
-                        self.output["cells"].insert(0, h)
-            except:
-                self.warn(
-                    "Invalid jupyter headers. "
-                    "jupyter_headers: {}, lang: {}"
-                    .format(self.jupyter_headers, self.lang))
 
         # Update metadata
         if self.jupyter_kernels is not None:

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -202,13 +202,5 @@ jupyter_kernels = {
     }
 }
 
-# Configure Jupyter headers
-jupyter_headers = {
-    "python3": [
-    ],
-    "julia": [
-    ],
-}
-
 # Prepend a Welcome Message to Each Notebook
 jupyter_welcome_block = "welcome.rst"


### PR DESCRIPTION
This removes the ability to add header blocks to every produced notebook which were defined in the ``conf.py`` file. This was initially used to add some code such as to switch ``autosave`` off for every produced notebook. 

This will be replaced with the ability to specify a header rst which can be used to add in RST and/or code to the top of every produced notebook. This is currently called ``welcome_message`` but this should be renamed as ``header_rst``. 
