### PR TITLE
Update jupyter_welcome_message to be more unified terminology ``header_block``

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -8,7 +8,7 @@ def setup(app):
     app.add_config_value("jupyter_conversion_mode", None, "jupyter")
     app.add_config_value("jupyter_write_metadata", True, "jupyter")
     app.add_config_value("jupyter_static_file_path", [], "jupyter")
-    app.add_config_value("jupyter_header_block", None, "jupyter")
+    app.add_config_value("jupyter_header_block", "", "jupyter")
     app.add_config_value("jupyter_options", None, "jupyter")
 
     return {

--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -8,7 +8,7 @@ def setup(app):
     app.add_config_value("jupyter_conversion_mode", None, "jupyter")
     app.add_config_value("jupyter_write_metadata", True, "jupyter")
     app.add_config_value("jupyter_static_file_path", [], "jupyter")
-    app.add_config_value("jupyter_welcome_block", None, "jupyter")
+    app.add_config_value("jupyter_header_block", None, "jupyter")
     app.add_config_value("jupyter_options", None, "jupyter")
 
     return {

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -38,18 +38,18 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_headers = builder.config["jupyter_headers"]
         self.jupyter_write_metadata = builder.config["jupyter_write_metadata"]
 
-        # Welcome message block
+        # Header Block
         template_paths = builder.config["templates_path"]
-        welcome_block_filename = builder.config["jupyter_welcome_block"]
+        header_block_filename = builder.config["jupyter_header_block"]
 
-        full_path_to_welcome = None
+        full_path_to_header_block = None
         for template_path in template_paths:
-            if os.path.isfile(template_path + "/" + welcome_block_filename):
-                full_path_to_welcome = os.path.normpath(
-                    template_path + "/" + welcome_block_filename)
+            if os.path.isfile(template_path + "/" + header_block_filename):
+                full_path_to_header_block = os.path.normpath(
+                    template_path + "/" + header_block_filename)
 
-        if full_path_to_welcome:
-            with open(full_path_to_welcome) as input_file:
+        if full_path_to_header_block:
+            with open(full_path_to_header_block) as input_file:
                 lines = input_file.readlines()
 
             line_text = "".join(lines)
@@ -58,7 +58,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
             nb_header_block = nbformat.v4.new_markdown_cell(
                 formatted_line_text)
 
-            # Add the welcome block to the output stream straight away
+            # Add the header block to the output stream straight away
             self.output["cells"].append(nb_header_block)
 
         # Write metadata

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -210,5 +210,3 @@ jupyter_headers = {
     ],
 }
 
-# Prepend a Welcome Message to Each Notebook
-jupyter_welcome_block = "welcome.rst"


### PR DESCRIPTION
This PR updates ``jupyter_welcome_message`` option in the ``conf.py`` to ``jupyter_header_block``.

One can add a header to generated notebooks by adding an ``rst`` file and setting it in the ``conf.py`` file. 

```
jupyter_header_block = "welcome.rst"
```

- [ ] I need to add a test for this option - but that will trigger an update on all tests in ``ipynb`` unless we tests ``conf`` options in a separate environment. 