### PR TITLE
resolve error with windows delimiters

### DIFF
--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -115,4 +115,4 @@ def get_source_file_name(filepath, srcdir):
             raise ValueError("File path does not exist in the source directory")
 
     file_name_list = file_path_list[len(srcdir_path_list) - 1:]
-    return delimiter.join(file_name_list)
+    return delimiter.join("/") # Does this also need to be changed? 

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -1,4 +1,5 @@
 import os.path
+import os 
 import nbformat.v4
 from xml.etree.ElementTree import ElementTree
 from enum import Enum
@@ -105,12 +106,13 @@ class JupyterOutputCellGenerators(Enum):
 
 
 def get_source_file_name(filepath, srcdir):
-    file_path_list = filepath.split("/")
-    srcdir_path_list = srcdir.split("/")
+    delimiter = os.sep 
+    file_path_list = filepath.split(delimiter)
+    srcdir_path_list = srcdir.split(delimiter)
 
     for i in range(len(srcdir_path_list)):
         if srcdir_path_list[i] != file_path_list[i]:
             raise ValueError("File path does not exist in the source directory")
 
     file_name_list = file_path_list[len(srcdir_path_list) - 1:]
-    return "/".join(file_name_list)
+    return delimiter.join(file_name_list)

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -115,4 +115,4 @@ def get_source_file_name(filepath, srcdir):
             raise ValueError("File path does not exist in the source directory")
 
     file_name_list = file_path_list[len(srcdir_path_list) - 1:]
-    return delimiter.join("/") # Does this also need to be changed? 
+    return "/".join(file_name_list) # Does this also need to be changed? 


### PR DESCRIPTION
Resolves @jlperla's issue QuantEcon/sphinxcontrib-jupyter.minimal#2, which was fixed by switching UNIX-style delimiters `/` in a file to Windows ones `\`. This PR replaces them with a generic delimiter `os.sep`. 

Note: There's one place in this function where `/` is still hardcoded, but since it didn't seem to break anything, I didn't want to touch it. I left a comment there.  

