### PR TITLE
FEAT: Add support to skip only directives that are not jupyter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,8 @@ Other Supported Directives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. ``.. note::`` - the raw contents of this directive is included 
-into the notebook as a block quote with a **Note** title. 
+into the notebook as a block quote with a **Note** title.
+1. ``.. only::`` - this will skip any only content that is not jupyter 
 
 .. _configuration:
 

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -41,9 +41,6 @@ class JupyterTranslator(JupyterCodeTranslator, object):
     # specific visit and depart methods
     # ---------------------------------
 
-    # =========
-    # Sections
-    # =========
     def visit_document(self, node):
         """at start
         """
@@ -56,6 +53,16 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         """
         self.add_markdown_cell()
         JupyterCodeTranslator.depart_document(self, node)
+
+    # =========
+    # Sections
+    # =========
+
+    def visit_only(self, node):
+        pass
+    
+    def depart_only(self, node):
+        pass
 
     def visit_topic(self, node):
         self.in_topic = True

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -18,6 +18,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    images
    math
    notes
+   only
    links
    links_target
    lists

--- a/tests/ipynb/only.ipynb
+++ b/tests/ipynb/only.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Only\n",
+    "\n",
+    "This tests for support of the only directive with an html only block to follow this\n",
+    "\n",
+    "there should be no html block above this text\n",
+    "\n",
+    "and one related to Jupyter\n",
+    "\n",
+    "this should show up\n",
+    "\n",
+    "there should be: **this should show up** above this text"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/only.rst
+++ b/tests/only.rst
@@ -1,0 +1,18 @@
+Only
+====
+
+This tests for support of the only directive with an html only block to follow this
+
+.. only:: html
+
+    this text should **not** show up for Jupyter notebook
+
+there should be no html block above this text
+
+and one related to Jupyter
+
+.. only:: jupyter
+
+   this should show up
+
+there should be: **this should show up** above this text


### PR DESCRIPTION
add support for skipping only content relating to other builders and associated test

this will skip items like:

```
.. only:: html
```