### PR TITLE
FEAT: Add support for inline literal markup in RST

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -283,6 +283,12 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         else:
             self.markdown_lines.append("**")
 
+    def visit_literal(self, node):
+        self.markdown_lines.append("`")
+
+    def depart_literal(self, node):
+        self.markdown_lines.append("`")
+
     # figures
     def visit_figure(self, node):
         pass

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -16,6 +16,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    code_blocks
    quote
    images
+   inline
    math
    notes
    only

--- a/tests/inline.rst
+++ b/tests/inline.rst
@@ -1,0 +1,20 @@
+Inline
+======
+
+A test suite for inline items
+
+Code
+~~~~
+
+Here is some inline python ``import numpy as np`` that should be displayed
+
+and some text that is not code ``here``
+
+Math
+~~~~
+
+Inline maths with inline role: :math:`x^3+\frac{1+\sqrt{2}}{\pi}`
+
+Inline maths using dollar signs (not supported yet): $x^3+\frac{1+\sqrt{2}}{\pi}$ as the 
+backslashes are removed.
+

--- a/tests/ipynb/code_blocks.ipynb
+++ b/tests/ipynb/code_blocks.ipynb
@@ -178,7 +178,7 @@
     "**Note:** This sphinx extension does not currently parse blocks internally\n",
     "\n",
     "Long Pandas DataFrame’s with more than three digits in the index column will\n",
-    "have a ... in the output which shouldn’t be considered a Python line\n",
+    "have a `...` in the output which shouldn’t be considered a Python line\n",
     "continuation prompt:"
    ]
   },
@@ -483,21 +483,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python",
+   "language": "python3",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tests/ipynb/inline.ipynb
+++ b/tests/ipynb/inline.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inline\n",
+    "\n",
+    "A test suite for inline items"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Code\n",
+    "\n",
+    "Here is some inline python `import numpy as np` that should be displayed\n",
+    "\n",
+    "and some text that is not code `here`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Math\n",
+    "\n",
+    "Inline maths with inline role: $ x^3+\\frac{1+\\sqrt{2}}{\\pi} $\n",
+    "\n",
+    "Inline maths using dollar signs (not supported yet): $x^3+frac{1+sqrt{2}}{pi}$ as the\n",
+    "backslashes are removed."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/ipynb/simple_notebook.ipynb
+++ b/tests/ipynb/simple_notebook.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Text will appear as a markdown cell in the notebook split by code-blocks.\n",
     "\n",
-    "To add a code block you can use code-block directives such as:"
+    "To add a code block you can use `code-block` directives such as:"
    ]
   },
   {


### PR DESCRIPTION
This PR adds support for parsing inline literals and adds a test case for inline elements.

These include elements in RST such as

```rst
This is a ``import numpy as np`` inline literal
```