### PR TITLE
FEAT: Add configuration option to allow parsing of html only blocks for Jupyter notebooks

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -12,6 +12,7 @@ def setup(app):
     app.add_config_value("jupyter_default_lang", "python3", "jupyter")
     app.add_config_value("jupyter_drop_solutions", True, "jupyter")
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
+    app.add_config_value("jupyter_allow_html_only", True, "jupyter")
     
 
     return {

--- a/tests/only.rst
+++ b/tests/only.rst
@@ -7,7 +7,7 @@ This tests for support of the only directive with an html only block to follow t
 
     this text should **not** show up for Jupyter notebook
 
-there should be no html block above this text
+there should be no html block above this text unless option jupyter_allow_html_only is True
 
 and one related to Jupyter
 


### PR DESCRIPTION
This PR adds the option to include html only blocks in jupyter notebooks.

- [ ] check test