### PR TITLE
FEAT: allow jupyter notebooks to capture html only blocks in output

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -1,5 +1,5 @@
 from .builders.jupyter import JupyterBuilder
-
+from .transform import JupyterOnlyTransform
 
 def setup(app):
     app.add_builder(JupyterBuilder)
@@ -12,7 +12,9 @@ def setup(app):
     app.add_config_value("jupyter_default_lang", "python3", "jupyter")
     app.add_config_value("jupyter_drop_solutions", True, "jupyter")
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
-    
+
+    app.add_transform(JupyterOnlyTransform)
+    app.add_config_value("jupyter_allow_html_only", False, "jupyter")
 
     return {
         "version": "0.2.1",

--- a/sphinxcontrib/jupyter/transform/__init__.py
+++ b/sphinxcontrib/jupyter/transform/__init__.py
@@ -1,0 +1,42 @@
+"""
+Add sphinxcontrib-jupyter transforms
+"""
+
+from docutils import nodes
+from sphinx.transforms import SphinxTransform
+from sphinx import addnodes
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+def process_only_nodes(config, document, tags):
+    # type: (nodes.Node, Tags) -> None
+    """Filter ``only`` nodes which does not match *tags* or html (through config)"""
+    ret_html_cell = config['jupyter_allow_html_only'] 
+    for node in document.traverse(addnodes.only):
+        try:
+            ret = tags.eval_condition(node['expr'])  #check for jupyter only
+            if ret_html_cell and node['expr'] == 'html':  #allow html only cells if option is specified
+                ret = True
+        except Exception as err:
+            logger.warning(__('exception while evaluating only directive expression: %s'), err,
+                           location=node)
+            node.replace_self(node.children or nodes.comment())
+        else:
+            if ret:
+                node.replace_self(node.children or nodes.comment())
+            else:
+                # A comment on the comment() nodes being inserted: replacing by [] would
+                # result in a "Losing ids" exception if there is a target node before
+                # the only node, so we make sure docutils can transfer the id to
+                # something, even if it's just a comment and will lose the id anyway...
+                node.replace_self(nodes.comment())
+
+
+class JupyterOnlyTransform(SphinxTransform):
+
+    default_priority = 50
+
+    def apply(self):
+        process_only_nodes(self.config, self.document, self.app.builder.tags)
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,4 +25,4 @@ server:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -P

--- a/tests/ipynb/only.ipynb
+++ b/tests/ipynb/only.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Only\n",
     "\n",
-    "This tests for support of the only directive with an html only block to follow this\n",
+    "This tests for support of the only directive with an html only block to follow this (unless option **jupyter_allow_html_only** is True)\n",
     "\n",
     "there should be no html block above this text\n",
     "\n",

--- a/tests/only.rst
+++ b/tests/only.rst
@@ -1,11 +1,11 @@
 Only
 ====
 
-This tests for support of the only directive with an html only block to follow this
+This tests for support of the only directive with an html only block to follow this (unless option **jupyter_allow_html_only** is True)
 
 .. only:: html
 
-    this text should **not** show up for Jupyter notebook
+    I am inside an HTML only block
 
 there should be no html block above this text
 


### PR DESCRIPTION
This PR adds a transform to parse ``jupyter_allow_html_only`` configuration to include html only blocks in generated jupyter notebooks

The default configuration value is `False` therefore by default the blocks that are included are:

```
.. only:: jupyter
```
blocks