### PR TITLE
FIX: fix issue with odd number of spaces breaking nested lists

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -338,7 +338,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         self.list_level += 1
         # markdown does not have option changing bullet chars
         self.bullets.append("-")
-        self.indents.append(len(self.bullets[-1]) + 1)
+        self.indents.append(len(self.bullets[-1]))
 
     def depart_bullet_list(self, node):
         self.list_level -= 1
@@ -354,7 +354,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         self.list_level += 1
         # markdown does not have option changing bullet chars
         self.bullets.append("1.")
-        self.indents.append(len(self.bullets[-1]) + 1)
+        self.indents.append(len(self.bullets[-1]))
 
     def depart_enumerated_list(self, node):
         self.list_level -= 1

--- a/tests/ipynb/code_blocks.ipynb
+++ b/tests/ipynb/code_blocks.ipynb
@@ -455,10 +455,10 @@
     "\n",
     "<dl style='margin: 20px 0;'>\n",
     "<dt>ok to fail? (missing mandatory new line after ::)::</dt>\n",
-    "   <dd>\n",
-    "   >>> 1+1</dd>\n",
-    "   \n",
-    "   </dl>"
+    "  <dd>\n",
+    "  >>> 1+1</dd>\n",
+    "  \n",
+    "  </dl>"
    ]
   },
   {

--- a/tests/ipynb/lists.ipynb
+++ b/tests/ipynb/lists.ipynb
@@ -72,11 +72,11 @@
     "## Bullets\n",
     "\n",
     "- b1  \n",
-    "  - c1  \n",
-    "  - c2  \n",
+    " - c1  \n",
+    " - c2  \n",
     "- b2  \n",
-    "  - d1  \n",
-    "  - d2  \n",
+    " - d1  \n",
+    " - d2  \n",
     "- b3  "
    ]
   },
@@ -88,9 +88,21 @@
     "\n",
     "- this is  \n",
     "- a list  \n",
-    "  - with a nested list  \n",
-    "  - and some subitems  \n",
+    " - with a nested list  \n",
+    " - and some subitems  \n",
     "- and here the parent list continues  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Malformed Lists that seem to work in HTML\n",
+    "\n",
+    "- first item  \n",
+    "- second item  \n",
+    " \n",
+    "     - a sub item that is spaced with four spaces rather than two  "
    ]
   }
  ],

--- a/tests/lists.rst
+++ b/tests/lists.rst
@@ -60,3 +60,13 @@ Bullets
   * and some subitems
 
 * and here the parent list continues
+
+Malformed Lists that seem to work in HTML
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* first item
+
+* second item
+
+    * a sub item that is spaced with four spaces rather than two
+


### PR DESCRIPTION
This PR fixes an issue which generated an `odd` number of spaces when translating to markdown nested lists which broke rendering. 