### PR TITLE
FEAT: Add support for footnotes rubric

### DIFF
--- a/tests/footnotes.rst
+++ b/tests/footnotes.rst
@@ -1,0 +1,19 @@
+Rubric
+======
+
+Define the government's one-period loss function [#f1]_
+
+.. math::
+    :label: target
+
+    r(y, u)  =  y' R y  + u' Q u
+
+
+History dependence has two sources: (a) the government's ability to commit [#f2]_ to a sequence of rules at time :math:`0`
+
+
+.. rubric:: Footnotes
+
+.. [#f1] The problem assumes that there are no cross products between states and controls in the return function.  A simple transformation  converts a problem whose return function has cross products into an equivalent problem that has no cross products.
+
+.. [#f2] The government would make different choices were it to choose sequentially, that is,  were it to select its time :math:`t` action at time :math:`t`.

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -14,6 +14,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    simple_notebook
    tables
    code_blocks
+   footnotes
    quote
    ignore
    images

--- a/tests/ipynb/footnotes.ipynb
+++ b/tests/ipynb/footnotes.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rubric\n",
+    "\n",
+    "Define the government’s one-period loss function <sup>[1](#f1)</sup>\n",
+    "\n",
+    "\n",
+    "<a id='equation-target'></a>\n",
+    "<table width=100%><tr style='background-color: #FFFFFF !important;'>\n",
+    "<td width=10%></td>\n",
+    "<td width=80%>\n",
+    "$$\n",
+    "r(y, u)  =  y' R y  + u' Q u\n",
+    "$$\n",
+    "</td><td width=10% style='text-align:center !important;'>\n",
+    "(1)\n",
+    "</td></tr></table>\n",
+    "\n",
+    "History dependence has two sources: (a) the government’s ability to commit <sup>[2](#f2)</sup> to a sequence of rules at time $ 0 $"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Footnotes**\n",
+    "\n",
+    "<a id='f1'></a>\n",
+    "*[1]* The problem assumes that there are no cross products between states and controls in the return function.  A simple transformation  converts a problem whose return function has cross products into an equivalent problem that has no cross products.\n",
+    "\n",
+    "<a id='f2'></a>\n",
+    "*[2]* The government would make different choices were it to choose sequentially, that is,  were it to select its time $ t $ action at time $ t $."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds support for a footnotes rubric

```rst
.. rubric:: Footnotes

.. [#f1] a footnote here
```

and can be referenced using the ``[#f1]_`` identified in the text.

This will result in a footnote id number added as ``html`` super text with a footnotes section placed within the notebook titled ``Footnotes`` with a listing. 