### PR TITLE
FEAT: adding support for language synonyms such as python and ipython

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -10,6 +10,7 @@ def setup(app):
     app.add_config_value("jupyter_header_block", "", "jupyter")
     app.add_config_value("jupyter_options", None, "jupyter")
     app.add_config_value("jupyter_default_lang", "python3", "jupyter")
+    app.add_config_value("jupyter_lang_synonyms", [], "jupyter")
     app.add_config_value("jupyter_drop_solutions", True, "jupyter")
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
 

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -38,6 +38,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_write_metadata = builder.config["jupyter_write_metadata"]
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]
         self.jupyter_drop_tests = builder.config["jupyter_drop_tests"]
+        self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
 
         # Header Block
         template_paths = builder.config["templates_path"]
@@ -175,7 +176,10 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         # was specified as the default language, do not create a code block for it - turn it into
         # markup instead.
         if self.nodelang != self.langTranslator.translate(self.lang):
-            self.output_cell_type = JupyterOutputCellGenerators.MARKDOWN
+            if self.nodelang in self.jupyter_lang_synonyms:
+                pass
+            else:
+                self.output_cell_type = JupyterOutputCellGenerators.MARKDOWN
 
     def depart_literal_block(self, node):
         if self.solution and self.jupyter_drop_solutions:    

--- a/tests/code_synonyms.rst
+++ b/tests/code_synonyms.rst
@@ -1,0 +1,30 @@
+Code Synonyms
+=============
+
+This is useful for when you want to highlight two languages such as ``python`` and ``ipython``
+syntax but want each to be executable within the same document.
+
+This can be done in the ``conf.py`` file through the ``jupyter_lang_synonyms = ["ipython"]`` option
+
+.. code-block:: python3
+
+   import numpy as np 
+   a = np.random.rand(10000)
+
+and now an ipython block
+
+.. code-block:: ipython
+
+    %%file us_cities.txt
+    new york: 8244910
+    los angeles: 3819702
+    chicago: 2707120 
+    houston: 2145146
+    philadelphia: 1536471
+    phoenix: 1469471
+    san antonio: 1359758
+    san diego: 1326179
+    dallas: 1223229
+
+this will generate a file ``us_cities.txt`` in the local directory using an ipython 
+cellmagic

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -213,3 +213,5 @@ jupyter_drop_solutions = True
 
 # Tests configurations 
 jupyter_drop_tests = True
+
+jupyter_lang_synonyms = ["ipython"]

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -10,6 +10,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   code_synonyms
    download
    equation_labels
    simple_notebook

--- a/tests/ipynb/code_synonyms.ipynb
+++ b/tests/ipynb/code_synonyms.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Code Synonyms\n",
+    "\n",
+    "This is useful for when you want to highlight two languages such as `python` and `ipython`\n",
+    "syntax but want each to be executable within the same document.\n",
+    "\n",
+    "This can be done in the `conf.py` file through the `jupyter_lang_synonyms = [\"ipython\"]` option"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "a = np.random.rand(10000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and now an ipython block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%file us_cities.txt\n",
+    "new york: 8244910\n",
+    "los angeles: 3819702\n",
+    "chicago: 2707120\n",
+    "houston: 2145146\n",
+    "philadelphia: 1536471\n",
+    "phoenix: 1469471\n",
+    "san antonio: 1359758\n",
+    "san diego: 1326179\n",
+    "dallas: 1223229"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "this will generate a file `us_cities.txt` in the local directory using an ipython\n",
+    "cellmagic"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR will allow the use of ``python`` and ``ipython`` (for example) to be in a single notebook and they will both be included as executable code-blocks.