### PR TITLE
FEAT: allow html targeting in links for use with nbconvert

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -16,6 +16,7 @@ def setup(app):
 
     app.add_transform(JupyterOnlyTransform)
     app.add_config_value("jupyter_allow_html_only", False, "jupyter")
+    app.add_config_value("jupyter_target_html", False, "jupyter")
 
     return {
         "version": "0.2.1",

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -20,6 +20,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         self.indent_char = " "
         self.indent = self.indent_char * 4
         self.default_ext = ".ipynb"
+        self.html_ext = ".html"
 
         # Variables used in visit/depart
         self.in_code_block = False  # if False, it means in markdown_cell
@@ -371,8 +372,10 @@ class JupyterTranslator(JupyterCodeTranslator, object):
 
                 # add default extension(.ipynb)
                 if "internal" in node.attributes and node.attributes["internal"] == True:
-                    refuri = self.add_extension_to_inline_link(
-                        refuri, self.default_ext)
+                    if self.jupyter_target_html:
+                        refuri = self.add_extension_to_inline_link(refuri, self.html_ext)
+                    else:
+                        refuri = self.add_extension_to_inline_link(refuri, self.default_ext)
             else:
                 # in-page link
                 if "refid" in node:

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -39,6 +39,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]
         self.jupyter_drop_tests = builder.config["jupyter_drop_tests"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
+        self.jupyter_target_html = builder.config["jupyter_target_html"]
 
         # Header Block
         template_paths = builder.config["templates_path"]


### PR DESCRIPTION
This PR allows for links to be formed using ``html`` instead of ``ipynb`` extensions for projects that want to compile using ``nbconvert --to=html``. This will ensure links generated are linkable at the ``html`` level. 

It is activated in ``conf.py`` by adding ``jupyter_target_html = True``