### PR TITLE
FEAT: Add :output: to Jupyter Directive 

### DIFF
--- a/sphinxcontrib/jupyter/directive/jupyter.py
+++ b/sphinxcontrib/jupyter/directive/jupyter.py
@@ -25,7 +25,6 @@ class Jupyter(Directive):
         # gives you access to the parameter stored
         # in the main configuration file (conf.py)
         config = env.config
-        options = self.options
 
         # we create a new cell and we add it to the node tree
         node = JupyterNode()


### PR DESCRIPTION
(Reset and reopen PR #115 )
Add the ability to include output to code-blocks using the jupyter directive

```rst
.. jupyter:: 
   :type: output
```
