### PR TITLE
FEAT: Add :type: output cell into the jupyter directive.

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -1,5 +1,5 @@
 from .builders.jupyter import JupyterBuilder
-from .directive.jupyter import jupyter_node
+from .directive.jupyter import JupyterNode
 from .directive.jupyter import Jupyter as JupyterDirective
 from .transform import JupyterOnlyTransform
 
@@ -18,7 +18,7 @@ def setup(app):
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
     
     # Jupyter Directive
-    app.add_node(jupyter_node)              #include in html=(visit_jupyter_node, depart_jupyter_node)
+    app.add_node(JupyterNode)              #include in html=(visit_jupyter_node, depart_jupyter_node)
     app.add_directive("jupyter", JupyterDirective)
    
     app.add_transform(JupyterOnlyTransform)

--- a/sphinxcontrib/jupyter/directive/jupyter.py
+++ b/sphinxcontrib/jupyter/directive/jupyter.py
@@ -1,7 +1,7 @@
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 
-class jupyter_node(nodes.Structural, nodes.Element): 
+class JupyterNode(nodes.Structural, nodes.Element): 
     pass
 
 class Jupyter(Directive):
@@ -13,8 +13,10 @@ class Jupyter(Directive):
     required_arguments = 0
     optional_arguments = 0
     final_argument_whitespace = True
-    option_spec = {'cell-break': directives.flag,
-                   'type': directives.unchanged}
+    option_spec = {
+        'cell-break': directives.flag,
+        'type': directives.unchanged
+        }
     has_content = True
     add_index = False
  
@@ -23,16 +25,15 @@ class Jupyter(Directive):
         # gives you access to the parameter stored
         # in the main configuration file (conf.py)
         config = env.config
-         
-        # we create a cell
-        idb = nodes.make_id("new-cell")
-        cell = nodes.section(ids=[idb])
-         
+
         # we create a new cell and we add it to the node tree
-        node = jupyter_node()
+        node = JupyterNode()
         if 'cell-break' in self.options:
             node['cell-break'] = True
- 
+        elif 'type' in self.options:
+            node.children.append(nodes.literal(self.content.data))
+            node['type'] = self.options['type']
+
         # we return the result
         return [ node ]
 

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -268,7 +268,11 @@ class JupyterTranslator(JupyterCodeTranslator, object):
 
     def visit_footnote_reference(self, node):
         self.in_footnote_reference = True
-        self.markdown_lines.append("<sup>[{}](#{})</sup>".format(node.astext(), node.attributes['refid']))
+        if self.jupyter_target_html:
+            link = "<sup><a href=#{}>[{}]</a></sup>".format(node.attributes['refid'], node.astext())
+        else:
+            link = "<sup>[{}](#{})</sup>".format(node.astext(), node.attributes['refid'])
+        self.markdown_lines.append(link)
         raise nodes.SkipNode
 
     def depart_footnote_reference(self, node):
@@ -529,7 +533,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
                 id_text += "{} ".format(id_)
             else:
                 id_text = id_text[:-1]
-            self.markdown_lines.append("<a id='{}'></a>\n*[{}]* ".format(id_text, node.astext()))
+            self.markdown_lines.append("<a id='{}'></a>\n**[{}]** ".format(id_text, node.astext()))
             raise nodes.SkipNode
         if self.in_citation:
             self.markdown_lines.append("\[")

--- a/tests/ipynb/index.ipynb
+++ b/tests/ipynb/index.ipynb
@@ -27,6 +27,7 @@
     "  - [Code](inline.ipynb#code)\n",
     "  - [Math](inline.ipynb#math)\n",
     "- [Jupyter Directive](jupyter.ipynb#)\n",
+    "  - [Output Cells](jupyter.ipynb#output-cells)\n",
     "- [Links](links.ipynb#)\n",
     "- [Links Target](links_target.ipynb#)\n",
     "- [List](lists.ipynb#)\n",

--- a/tests/ipynb/jupyter.ipynb
+++ b/tests/ipynb/jupyter.ipynb
@@ -10,23 +10,45 @@
     "\n",
     "The following jupyter directive with cell-break option should\n",
     "split this text and the text that follows into different IN\n",
-    "blocks in the notebook"
+    "blocks in the notebook\n",
+    "\n",
+    "This text should follow in a separate cell."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This text should follow in a separate cell."
+    "## Output Cells\n",
+    "\n",
+    "The following code block should have an output block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``"
    ]
   }
  ],
  "metadata": {
+  "filename": "jupyter.rst",
   "kernelspec": {
    "display_name": "Python",
    "language": "python3",
    "name": "python3"
-  }
+  },
+  "title": "Jupyter Directive"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/tests/jupyter.rst
+++ b/tests/jupyter.rst
@@ -12,4 +12,17 @@ blocks in the notebook
 
 This text should follow in a separate cell.
 
+Output Cells
+------------
 
+The following code block should have an output block
+
+.. code-block:: python3
+
+    import numpy as np 
+
+.. jupyter::
+   :type: output
+
+   This text is in an output block
+   that contains two lines of text


### PR DESCRIPTION
( Setting up again this PR, since it was wrongly merged with the master branch)

Add the ability to include output to code-blocks using the jupyter directive

```rst
.. jupyter:: 
   :type: output
```
