### PR TITLE
FEAT: Add global ignore to no-execute code-blocks

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -16,6 +16,7 @@ def setup(app):
     app.add_config_value("jupyter_lang_synonyms", [], "jupyter")
     app.add_config_value("jupyter_drop_solutions", True, "jupyter")
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
+    app.add_config_value("jupyter_ignore_no_execute", False, "jupyter")
     
     # Jupyter Directive
     app.add_node(jupyter_node)              #include in html=(visit_jupyter_node, depart_jupyter_node)

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -39,6 +39,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_write_metadata = builder.config["jupyter_write_metadata"]
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]
         self.jupyter_drop_tests = builder.config["jupyter_drop_tests"]
+        self.jupyter_ignore_no_execute = builder.config["jupyter_ignore_no_execute"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
 
@@ -166,7 +167,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
     #  code blocks
     # ================
     def visit_literal_block(self, node):
-        _parse_class = JupyterOutputCellGenerators.GetGeneratorFromClasses(node.attributes['classes'])
+        _parse_class = JupyterOutputCellGenerators.GetGeneratorFromClasses(self, node)
         self.output_cell_type = _parse_class["type"]
         self.solution = _parse_class["solution"]
         self.test = _parse_class["test"]

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -66,7 +66,7 @@ class JupyterOutputCellGenerators(Enum):
     CODE_OUTPUT = 3
 
     @staticmethod
-    def GetGeneratorFromClasses(class_list):
+    def GetGeneratorFromClasses(obj, node):
         """
         Infers the type of output cell to be generated from the class attributes in the original Sphinx cell.
 
@@ -78,9 +78,10 @@ class JupyterOutputCellGenerators(Enum):
             "solution" : False,
             "test" : False 
             }
+        class_list = node.attributes['classes']
 
         for item in class_list:
-            if item == "no-execute":
+            if item == "no-execute" and not obj.jupyter_ignore_no_execute:
                 res["type"] = JupyterOutputCellGenerators.MARKDOWN
             elif item == "skip-test":
                 res["type"] = JupyterOutputCellGenerators.MARKDOWN


### PR DESCRIPTION
This PR adds a global ignore option for code blocks specified with ``:class: no-execute``. 

This can be enabled in the conf.py file through ``jupyter_ignore_no_execute=True`` or with ``sphinx-build`` using `D` flag and specifying ``jupyter_ignore_no_execute=1``