### PR TITLE
FEAT: add ignore for globally skipping skip-test flag in code-blocks

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -17,6 +17,7 @@ def setup(app):
     app.add_config_value("jupyter_drop_solutions", True, "jupyter")
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
     app.add_config_value("jupyter_ignore_no_execute", False, "jupyter")
+    app.add_config_value("jupyter_ignore_skip_test", False, "jupyter")
     
     # Jupyter Directive
     app.add_node(jupyter_node)              #include in html=(visit_jupyter_node, depart_jupyter_node)

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -40,6 +40,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]
         self.jupyter_drop_tests = builder.config["jupyter_drop_tests"]
         self.jupyter_ignore_no_execute = builder.config["jupyter_ignore_no_execute"]
+        self.jupyter_ignore_no_execute = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
 

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -40,7 +40,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]
         self.jupyter_drop_tests = builder.config["jupyter_drop_tests"]
         self.jupyter_ignore_no_execute = builder.config["jupyter_ignore_no_execute"]
-        self.jupyter_ignore_no_execute = builder.config["jupyter_ignore_skip_test"]
+        self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
 

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -83,7 +83,7 @@ class JupyterOutputCellGenerators(Enum):
         for item in class_list:
             if item == "no-execute" and not obj.jupyter_ignore_no_execute:
                 res["type"] = JupyterOutputCellGenerators.MARKDOWN
-            elif item == "skip-test":
+            elif item == "skip-test" and not obj.jupyter_ignore_skip_test:
                 res["type"] = JupyterOutputCellGenerators.MARKDOWN
             elif item == "output":
                 res["type"] = JupyterOutputCellGenerators.CODE_OUTPUT


### PR DESCRIPTION
This PR adds a global ignore option for code blocks specified with ``:class: skip-test``. 

This can be enabled in the conf.py file through ``jupyter_ignore_skip_test=True`` or with ``sphinx-build`` using `D` flag and specifying ``jupyter_ignore_skip_test=1``