### PR TITLE
FEAT: add urlprefix capability for images in notebooks

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -26,6 +26,8 @@ def setup(app):
     app.add_transform(JupyterOnlyTransform)
     app.add_config_value("jupyter_allow_html_only", False, "jupyter")
     app.add_config_value("jupyter_target_html", False, "jupyter")
+    app.add_config_value("jupyter_images_urlpath", None, "jupyter")
+
 
     return {
         "version": "0.2.1",

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -135,8 +135,10 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
         if self.jupyter_images_urlpath is not None:
-            fln = uri.split("/")[-1]
-            uri = self.jupyter_images_urlpath + fln
+            for file_path in self.jupyter_static_file_path:
+                if file_path in uri:
+                    uri = uri.replace(file_path +"/", self.jupyter_images_urlpath)
+                    break  #don't need to check other matches
         attrs = node.attributes
         # Construct HTML image
         image = '<img src="{}" '.format(uri)

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -49,6 +49,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         self.list_level = 0
         self.in_citation = False
 
+        self.images = []
         self.table_builder = None
 
     # specific visit and depart methods
@@ -132,6 +133,10 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         """
         return_markdown = False             #TODO: enable return markdown option
         uri = node.attributes["uri"]
+        self.images.append(uri)             #TODO: list of image files
+        if self.jupyter_images_urlpath is not None:
+            fln = uri.split("/")[-1]
+            uri = self.jupyter_images_urlpath + fln
         attrs = node.attributes
         # Construct HTML image
         image = '<img src="{}" '.format(uri)

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -43,6 +43,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
+        self.jupyter_images_urlpath = builder.config["jupyter_images_urlpath"]
 
         # Header Block
         template_paths = builder.config["templates_path"]

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -35,6 +35,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.output = nbformat.v4.new_notebook()
 
         # Variables defined in conf.py
+        self.jupyter_static_file_path = builder.config["jupyter_static_file_path"]
         self.jupyter_kernels = builder.config["jupyter_kernels"]
         self.jupyter_write_metadata = builder.config["jupyter_write_metadata"]
         self.jupyter_drop_solutions = builder.config["jupyter_drop_solutions"]

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -216,3 +216,8 @@ jupyter_drop_tests = True
 
 # Add Ipython as Synonym for tests
 jupyter_lang_synonyms = ["ipython"]
+
+# Image Prefix (enable web storage references)
+# jupyter_images_urlpath = "https://github.com/QuantEcon/sphinxcontrib-jupyter/raw/master/tests/_static/"
+
+


### PR DESCRIPTION
This PR adds the ability to specify a web location for embedded images in notebooks. This reduces the need to track `_static` assets as long as they are published in a web location. This PR addresses #116. 

## Usage

The option ``jupyter_images_urlpath = "https://<address>/"`` can be specified in the ``conf.py`` file which will swap the relative reference to ``_static`` for a web location. 

The default action is to use local file references in a `_static` folder with ``jupyter_images_urlpath = None``