### PR TITLE
FIX: fix markdown when no language is specified for highlighting

### DIFF
--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -108,7 +108,10 @@ class JupyterOutputCellGenerators(Enum):
             # Add triple backticks and the name of the language to the code block,
             # so that Jupyter renders the markdown correctly.
             language = translator.nodelang if translator.nodelang else ""
-            raw_markdown = "```" + language + "\n" + formatted_text + "\n```\n"
+            if language == "none":
+                raw_markdown = "```" + "\n" + formatted_text + "\n```\n"
+            else:
+                raw_markdown = "```" + language + "\n" + formatted_text + "\n```\n"
             res = nbformat.v4.new_markdown_cell(raw_markdown)
         else:
             raise Exception("Invalid output cell type passed to JupyterOutputCellGenerator.Generate.")

--- a/tests/code_blocks.rst
+++ b/tests/code_blocks.rst
@@ -278,4 +278,4 @@ A code block with none specified as highlighter
 
    import numpy as np
 
-should be a markdown block with no 
+should be a markdown block with no highlighting

--- a/tests/ipynb/code_blocks.ipynb
+++ b/tests/ipynb/code_blocks.ipynb
@@ -496,7 +496,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```none\n",
+    "```\n",
     "import numpy as np\n",
     "```\n"
    ]
@@ -505,16 +505,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "should be a markdown block with no"
+    "should be a markdown block with no highlighting"
    ]
   }
  ],
  "metadata": {
+  "filename": "code_blocks.rst",
   "kernelspec": {
    "display_name": "Python",
    "language": "python3",
    "name": "python3"
-  }
+  },
+  "title": "Code blocks"
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
This PR simply removes `none` from the markdown code-block when writing notebooks. This assists when rendering notebooks to html (via nbconvert).