### PR TITLE
FIX: change to text for none highlight in markdown

### DIFF
--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -109,7 +109,7 @@ class JupyterOutputCellGenerators(Enum):
             # so that Jupyter renders the markdown correctly.
             language = translator.nodelang if translator.nodelang else ""
             if language == "none":
-                raw_markdown = "```" + "\n" + formatted_text + "\n```\n"
+                raw_markdown = "```" + "text" + "\n" + formatted_text + "\n```\n"
             else:
                 raw_markdown = "```" + language + "\n" + formatted_text + "\n```\n"
             res = nbformat.v4.new_markdown_cell(raw_markdown)

--- a/tests/ipynb/code_blocks.ipynb
+++ b/tests/ipynb/code_blocks.ipynb
@@ -496,7 +496,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```text\n",
     "import numpy as np\n",
     "```\n"
    ]


### PR DESCRIPTION
This will enable better rendering when converting ipynb to html.