### PR TITLE
FEAT: add jupyter_target_html_urlprefix option

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -29,6 +29,7 @@ def setup(app):
     app.add_transform(JupyterOnlyTransform)
     app.add_config_value("jupyter_allow_html_only", False, "jupyter")
     app.add_config_value("jupyter_target_html", False, "jupyter")
+    app.add_config_value("jupyter_target_html_urlpath", None, "jupyter")
     app.add_config_value("jupyter_images_urlpath", None, "jupyter")
 
 

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -426,6 +426,8 @@ class JupyterTranslator(JupyterCodeTranslator, object):
                 if "internal" in node.attributes and node.attributes["internal"] == True:
                     if self.jupyter_target_html:
                         refuri = self.add_extension_to_inline_link(refuri, self.html_ext)
+                        if self.jupyter_target_html_urlpath is not None:
+                            refuri = self.jupyter_target_html_urlpath + refuri
                     else:
                         refuri = self.add_extension_to_inline_link(refuri, self.default_ext)
             else:

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -44,6 +44,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
+        self.jupyter_target_html_urlpath = builder.config["jupyter_target_html_urlpath"]
         self.jupyter_images_urlpath = builder.config["jupyter_images_urlpath"]
 
         # set the value of the cell metadata["slideshow"] to slide as the default option


### PR DESCRIPTION
add ability to specify a urlprefix for references (between notebooks) that will send users to the web location (rather than locally). 

``jupyter_target_html_urlprefix = "prefix path"``