### PR TITLE
FEAT: easier support for compiling notebooks with local images

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -30,7 +30,7 @@ def setup(app):
     app.add_config_value("jupyter_allow_html_only", False, "jupyter")
     app.add_config_value("jupyter_target_html", False, "jupyter")
     app.add_config_value("jupyter_target_html_urlpath", None, "jupyter")
-    app.add_config_value("jupyter_images_urlpath", None, "jupyter")
+    app.add_config_value("jupyter_images_urlpath", False, "jupyter")
 
 
     return {

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -158,7 +158,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         return_markdown = False             #TODO: enable return markdown option
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
-        if self.jupyter_images_urlpath is not None:
+        if self.jupyter_images_urlpath:
             for file_path in self.jupyter_static_file_path:
                 if file_path in uri:
                     uri = uri.replace(file_path +"/", self.jupyter_images_urlpath)


### PR DESCRIPTION
Allow easier support for working with local images in notebooks when overriding a conf.py.

A local command can then be used in sphinx Makefile to override the exisiting `conf.py`:

```
local:
	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_images_urlpath=0
```