### PR TITLE
Support sphinx >= 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - 2.7
   - 3.6
 
+env:
+  - SPHINX_VERSION=1.7.9
+  - SPHINX_VERSION=1.8.2
+
 notifications:
   email: false
 
@@ -21,7 +25,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION sphinx=1.8.2 nbformat
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION sphinx=$SPHINX_VERSION nbformat
   - pip install nbdime
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION sphinx=1.7.8 nbformat
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION sphinx=1.8.2 nbformat
   - pip install nbdime
   - python setup.py install
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ This sphinx extension can be used to build a collection of
 scientific publishing and hasn't been well tested outside of this
 domain. Please provide feedback as an issue to this repository.
 
-**Requires:** Sphinx >= 1.7.2 (for running tests). Sphinx >= 1.8 is currently not supported.
+**Requires:** Sphinx >= 1.7.2 (for running tests).
 
 Installation
 ------------

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -186,9 +186,8 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.solution = _parse_class["solution"]
         self.test = _parse_class["test"]
 
-        try:
-            self.nodelang = node.attributes["language"].strip()
-        except:
+        self.nodelang = node.attributes["language"].strip()
+        if self.nodelang == 'default':
             self.nodelang = self.lang
 
         # Translate the language name across from the Sphinx to the Jupyter namespace

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -186,7 +186,10 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.solution = _parse_class["solution"]
         self.test = _parse_class["test"]
 
-        self.nodelang = node.attributes["language"].strip()
+        try:
+            self.nodelang = node.attributes["language"].strip()
+        except KeyError:
+            self.nodelang = self.lang
         if self.nodelang == 'default':
             self.nodelang = self.lang
 


### PR DESCRIPTION
This PR makes sphinx >= 1.8 supported.

The main issue was with math_block. Math nodes do not have a latex attribute anymore 
with sphinx >= 1.8. Math nodes are now treated as every other node, i.e. a flag is raised
when the mode is activated, then the text (content) is written, then the
flag is down.


Closing #124 