### PR TITLE
ENH: added exercises directive

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -4,12 +4,24 @@ from .directive.jupyter import Jupyter as JupyterDirective
 from .directive.jupyter import JupyterDependency
 from .directive.exercise import ExerciseDirective, exercise_node
 from .transform import JupyterOnlyTransform
+from sphinx.writers.html import HTMLTranslator as HTML
+from sphinx.locale import admonitionlabels
+admonitionlabels["exercise"] = "Exercise"
+admonitionlabels["exercise_cfu"] = "Check for understanding"
 
-from docutils.writers.html5_polyglot import HTMLTranslator as HTML
 
 def _noop(*args, **kwargs):
     pass
 
+
+def visit_exercise_node(self, node):
+    iscfu = "cfu" in node.attributes["classes"]
+    name = "exercise_cfu" if iscfu else "exercise"
+    return HTML.visit_admonition(self, node, name)
+
+
+def depart_exercise_node(self, node):
+    return HTML.depart_admonition(self, node)
 
 
 def setup(app):
@@ -37,7 +49,7 @@ def setup(app):
     app.add_directive("exercise", ExerciseDirective)
     app.add_node(
         exercise_node,
-        html=(HTML.visit_admonition, HTML.depart_admonition)
+        html=(visit_exercise_node, depart_exercise_node)
     )
 
     app.add_transform(JupyterOnlyTransform)
@@ -45,7 +57,6 @@ def setup(app):
     app.add_config_value("jupyter_target_html", False, "jupyter")
     app.add_config_value("jupyter_target_html_urlpath", None, "jupyter")
     app.add_config_value("jupyter_images_urlpath", False, "jupyter")
-
 
     return {
         "version": "0.2.1",

--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -2,7 +2,15 @@ from .builders.jupyter import JupyterBuilder
 from .directive.jupyter import jupyter_node
 from .directive.jupyter import Jupyter as JupyterDirective
 from .directive.jupyter import JupyterDependency
+from .directive.exercise import ExerciseDirective, exercise_node
 from .transform import JupyterOnlyTransform
+
+from docutils.writers.html5_polyglot import HTMLTranslator as HTML
+
+def _noop(*args, **kwargs):
+    pass
+
+
 
 def setup(app):
     # Jupyter Builder and Options
@@ -19,13 +27,19 @@ def setup(app):
     app.add_config_value("jupyter_drop_tests", True, "jupyter")
     app.add_config_value("jupyter_ignore_no_execute", False, "jupyter")
     app.add_config_value("jupyter_ignore_skip_test", False, "jupyter")
-    
+
     # Jupyter Directive
-    app.add_node(jupyter_node)              #include in html=(visit_jupyter_node, depart_jupyter_node)
+    app.add_node(jupyter_node, html=(_noop, _noop))
     app.add_directive("jupyter", JupyterDirective)
     app.add_directive("jupyter-dependency", JupyterDependency)
 
-   
+    # exercise directive
+    app.add_directive("exercise", ExerciseDirective)
+    app.add_node(
+        exercise_node,
+        html=(HTML.visit_admonition, HTML.depart_admonition)
+    )
+
     app.add_transform(JupyterOnlyTransform)
     app.add_config_value("jupyter_allow_html_only", False, "jupyter")
     app.add_config_value("jupyter_target_html", False, "jupyter")

--- a/sphinxcontrib/jupyter/directive/exercise.py
+++ b/sphinxcontrib/jupyter/directive/exercise.py
@@ -1,0 +1,10 @@
+from docutils.nodes import Admonition, Element
+from docutils.parsers.rst.directives.admonitions import BaseAdmonition
+
+
+class exercise_node(Admonition, Element):
+    pass
+
+
+class ExerciseDirective(BaseAdmonition):
+    node_class = exercise_node

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -1,5 +1,5 @@
 import os.path
-import os 
+import os
 import nbformat.v4
 from xml.etree.ElementTree import ElementTree
 from enum import Enum
@@ -73,10 +73,10 @@ class JupyterOutputCellGenerators(Enum):
         Note that there is no guarantee as to the ordering or priority of output classes; a cell with the
         attribute ":class: no-execute output" is not considered to be well-defined.
         """
-        res = { 
+        res = {
             "type" : JupyterOutputCellGenerators.CODE,
             "solution" : False,
-            "test" : False 
+            "test" : False
             }
         class_list = node.attributes['classes']
 
@@ -90,9 +90,9 @@ class JupyterOutputCellGenerators(Enum):
             # Check for Solution
             elif item == "solution":
                 res["solution"] = True
-            # Check for Test. 
+            # Check for Test.
             elif item == "test":
-                res["test"] = True 
+                res["test"] = True
 
         return res
 
@@ -120,7 +120,7 @@ class JupyterOutputCellGenerators(Enum):
 
 
 def get_source_file_name(filepath, srcdir):
-    delimiter = os.sep 
+    delimiter = os.sep
     file_path_list = filepath.split(delimiter)
     srcdir_path_list = srcdir.split(delimiter)
 
@@ -129,5 +129,11 @@ def get_source_file_name(filepath, srcdir):
             raise ValueError("File path does not exist in the source directory")
 
     file_name_list = file_path_list[len(srcdir_path_list) - 1:]
-    return "/".join(file_name_list) # Does this also need to be changed? 
+    return "/".join(file_name_list) # Does this also need to be changed?
 
+
+def _str_to_lines(x):
+    if isinstance(x, str):
+        return list(map(lambda y: y.strip() + "\n", x.splitlines()))
+
+    return x

--- a/tests/exercises.rst
+++ b/tests/exercises.rst
@@ -1,0 +1,38 @@
+Exercises
+=========
+
+This notebook tests the new exercise directive defined in this package
+
+.. exercise::
+   :class: cfu
+
+   This is a check for understanding exercise
+
+   This is a note that has some *italic* and **bold** embedded
+
+   - list
+   - in
+   - exercise
+
+   .. code-block:: python
+
+      def foobar(x, y, z):
+         print(x, y, z)
+
+
+   And text after the code block
+
+   below is something that should be a real code block
+
+   .. code-block:: python3
+
+      def foobar(x, y, z):
+         print(x, y, z)
+
+   And text to follow
+
+text in between exercise
+
+.. exercise::
+
+   This is a normal exercise

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -16,6 +16,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    dependency
    download
    equation_labels
+   exercises
    footnotes
    ignore
    images
@@ -35,7 +36,7 @@ Welcome to sphinxcontrib-jupyter.minimal's documentation!
    tables
    tests
 
-   
+
 Indices and tables
 ==================
 

--- a/tests/ipynb/exercises.ipynb
+++ b/tests/ipynb/exercises.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exercises\n",
+    "\n",
+    "This notebook tests the new exercise directive defined in this package\n",
+    "\n",
+    "<blockquote>\n",
+    "\n",
+    "**Check for understanding**\n",
+    "\n",
+    "This is a check for understanding exercise\n",
+    "\n",
+    "This is a note that has some *italic* and **bold** embedded\n",
+    "\n",
+    "- list  \n",
+    "- in  \n",
+    "- exercise  \n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "def foobar(x, y, z):\n",
+    "   print(x, y, z)\n",
+    "```\n",
+    "And text after the code block\n",
+    "\n",
+    "below is something that should be a real code block\n",
+    "\n",
+    "\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide-output": false
+   },
+   "outputs": [],
+   "source": [
+    "def foobar(x, y, z):\n",
+    "   print(x, y, z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<blockquote>\n",
+    "And text to follow\n",
+    "\n",
+    "\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "text in between exercise\n",
+    "\n",
+    "<blockquote>\n",
+    "\n",
+    "**Exercise**\n",
+    "\n",
+    "This is a normal exercise\n",
+    "\n",
+    "\n",
+    "</blockquote>"
+   ]
+  }
+ ],
+ "metadata": {
+  "filename": "exercises.rst",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "title": "Exercises"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/ipynb/index.ipynb
+++ b/tests/ipynb/index.ipynb
@@ -18,6 +18,7 @@
     "- [dependency](dependency.ipynb)\n",
     "- [Download](download.ipynb)\n",
     "- [Equation Numbering](equation_labels.ipynb)\n",
+    "- [Exercises](exercises.ipynb)\n",
     "- [Rubric](footnotes.ipynb)\n",
     "- [Ignore](ignore.ipynb)\n",
     "  - [Comments](ignore.ipynb#comments)\n",


### PR DESCRIPTION
Hey @mmcky here is my first pass at making an `.. exercise` directive.

It seems to work pretty well for me, but isn't a totally clean/optimal implementation.

One place where I really had to do something I'm not proud of is in `JupyterTranslator.depart_literal_block`

Let me explain what I wanted, then I'll try to defend myself...

I wanted the ability to do something like

```rst
.. exercise::
   :class: cfu

   This is a check for understanding exercise

   This is a note that has some *italic* and **bold** embedded

   - list
   - in
   - exercise

   .. code-block:: python

      def foobar(x, y, z):
         print(x, y, z)


   And text after the code block
```

and have the entire exercise block -- code section and everything -- in a single markdown cell inside a `<blockquote>` element (html name for `>`).

The issue is that the `literal_block` handling caused a cell break to happen on either side of each `.. code-block`. To get around that I do the following:

- if I am in `depart_literal_block` AND am in an exercise AND the `literal_block` produced a markdown cell (not a code cell)...
- Then (and only then) pop that code filled markdown cell off the output, merge it with the current stack of `markdown_lines` and proceed onwards. 

This will cause the `.. code-block` to be written out to markdown, but then merged with the cell containing the prose for the `.. exercise`

I don't love the `pop` part and it seems like it might be fragile, but in my tests is does what I want 🤷‍♂️ 

