### PR TITLE
BUG: fix issue when parsing $ sign as special markdown syntax

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -125,6 +125,9 @@ class JupyterTranslator(JupyterCodeTranslator, object):
     def visit_Text(self, node):
         text = node.astext()
 
+        #Escape Special markdown chars
+        text = text.replace("$", "\$")
+
         if self.in_math:
             text = '$ {} $'.format(text.strip())
         elif self.in_math_block and self.math_block_label:

--- a/tests/ipynb/index.ipynb
+++ b/tests/ipynb/index.ipynb
@@ -56,6 +56,7 @@
     "- [Simple Notebook Example](simple_notebook.ipynb)\n",
     "  - [Math](simple_notebook.ipynb#math)\n",
     "  - [Tables](simple_notebook.ipynb#tables)\n",
+    "  - [Special Characters](simple_notebook.ipynb#special-characters)\n",
     "- [Slide option activated](slides.ipynb)\n",
     "  - [Math](slides.ipynb#math)\n",
     "- [Notebook without solutions](solutions.ipynb)\n",

--- a/tests/ipynb/inline.ipynb
+++ b/tests/ipynb/inline.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "Inline maths with inline role: $ x^3+\\frac{1+\\sqrt{2}}{\\pi} $\n",
     "\n",
-    "Inline maths using dollar signs (not supported yet): $x^3+frac{1+sqrt{2}}{pi}$ as the\n",
+    "Inline maths using dollar signs (not supported yet): \\$x^3+frac{1+sqrt{2}}{pi}\\$ as the\n",
     "backslashes are removed."
    ]
   }

--- a/tests/ipynb/math.ipynb
+++ b/tests/ipynb/math.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Inline maths with inline role: $ x^3+\\frac{1+\\sqrt{2}}{\\pi} $\n",
     "\n",
-    "Inline maths using dollar signs (not supported yet): $x^3+frac{1+sqrt{2}}{pi}$ as the\n",
+    "Inline maths using dollar signs (not supported yet): \\$x^3+frac{1+sqrt{2}}{pi}\\$ as the\n",
     "backslashes are removed.\n",
     "\n",
     "$$\n",

--- a/tests/ipynb/simple_notebook.ipynb
+++ b/tests/ipynb/simple_notebook.ipynb
@@ -18,7 +18,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "hide-output": false
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -27,7 +29,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "hide-output": false
+   },
    "outputs": [],
    "source": [
     "\"\"\"\n",
@@ -88,6 +92,15 @@
     "|:----------:|:----------:|:---------:|\n",
     "|body row 1|column 2|column 3|\n",
     "|body row 2|column 2|column 3|"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Special Characters\n",
+    "\n",
+    "Here is some text with \\$1.00 in it and another \\$2.00"
    ]
   }
  ],

--- a/tests/simple_notebook.rst
+++ b/tests/simple_notebook.rst
@@ -63,3 +63,8 @@ The extension supports the conversion of **simple** rst tables.
 +------------+------------+-----------+ 
 | body row 2 | column 2   | column 3  | 
 +------------+------------+-----------+ 
+
+Special Characters
+------------------
+
+Here is some text with $1.00 in it and another $2.00


### PR DESCRIPTION
This PR fixes an issue when using `$` sign in text. When multiple `$` chars are used in markdown they are interpreted as math. To fix this the extension escape `$` using `\$` when writing any `text` into markdown cells.