### PR TITLE
FIX: enable latex writer to compile

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -19,10 +19,8 @@ def visit_exercise_node(self, node):
     name = "exercise_cfu" if iscfu else "exercise"
     return HTML.visit_admonition(self, node, name)
 
-
 def depart_exercise_node(self, node):
     return HTML.depart_admonition(self, node)
-
 
 def setup(app):
     # Jupyter Builder and Options
@@ -41,7 +39,7 @@ def setup(app):
     app.add_config_value("jupyter_ignore_skip_test", False, "jupyter")
 
     # Jupyter Directive
-    app.add_node(jupyter_node, html=(_noop, _noop))
+    app.add_node(jupyter_node, html=(_noop, _noop), latex=(_noop, _noop))
     app.add_directive("jupyter", JupyterDirective)
     app.add_directive("jupyter-dependency", JupyterDependency)
 


### PR DESCRIPTION
This PR: 

- add ``noop`` to stop blocking latex writer on RST that uses jupyter directives.

**Note:** this passes a no operation function for now. 