### PR TITLE
added a check for code blocks when escaping

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -125,8 +125,9 @@ class JupyterTranslator(JupyterCodeTranslator, object):
     def visit_Text(self, node):
         text = node.astext()
 
-        #Escape Special markdown chars
-        text = text.replace("$", "\$")
+        #Escape Special markdown chars except in code block
+        if self.in_code_block == False:
+            text = text.replace("$", "\$")
 
         if self.in_math:
             text = '$ {} $'.format(text.strip())


### PR DESCRIPTION
This PR is just preventing the escaping of $ when it is a code block. Solves the issue [#173](https://github.com/QuantEcon/sphinxcontrib-jupyter/issues/173) . But have not tested the consequences it might have otherwise. I reckon we dont need escaping in any of the code blocks right? @arnavs @jlperla @mmcky 

fixes #173 