### PR TITLE
FIX: path was incorrect for copying some static assets

### DIFF
--- a/sphinxcontrib/jupyter/writers/make_site.py
+++ b/sphinxcontrib/jupyter/writers/make_site.py
@@ -22,7 +22,7 @@ class MakeSiteWriter():
         shutil.copytree("_build/jupyter/html/", JUPYTER_WEBSITE, symlinks=True)
 
         ## copies all the static files
-        shutil.copytree("_build/jupyter/_static/","_build_website/_static/", symlinks=True)
+        shutil.copytree("_build/jupyter/_static/", JUPYTER_WEBSITE + "_static/", symlinks=True)
 
         ## copies all theme files to _static folder 
         if os.path.exists("theme/static"):

--- a/sphinxcontrib/jupyter/writers/make_site.py
+++ b/sphinxcontrib/jupyter/writers/make_site.py
@@ -15,8 +15,8 @@ class MakeSiteWriter():
     def __init__(self):
         pass
     def build_website(self, builderSelf):
-        if os.path.exists("_build_website"):
-            shutil.rmtree("_build_website")
+        if os.path.exists(JUPYTER_WEBSITE):
+            shutil.rmtree(JUPYTER_WEBSITE)
 
         ## copies the html and downloads folder
         shutil.copytree("_build/jupyter/html/", JUPYTER_WEBSITE, symlinks=True)


### PR DESCRIPTION
This is a bug fix for copying static assets to the correct folder defined by JUPYTER_WEBSITE + "_static"