### PR TITLE
FEAT: add option to write images as markdown rather than html

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -72,6 +72,7 @@ def setup(app):
     app.add_config_value("jupyter_download_nb",False, "jupyter")
     app.add_config_value("jupyter_download_nb_urlpath", None, "jupyter")
     app.add_config_value("jupyter_images_urlpath", False, "jupyter")
+    app.add_config_value("jupyter_images_markdown", False, "jupyter")           #NOTE: Does not support scale, default=False
 
     return {
         "version": "0.2.1",

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -174,7 +174,6 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         implementation as is done in http://docutils.sourceforge.net/docs/ref/rst/directives.html#image
 
         """
-        return_markdown = False             #TODO: enable return markdown option
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
         if self.jupyter_images_urlpath:
@@ -183,24 +182,25 @@ class JupyterTranslator(JupyterCodeTranslator, object):
                     uri = uri.replace(file_path +"/", self.jupyter_images_urlpath)
                     break  #don't need to check other matches
         attrs = node.attributes
-        # Construct HTML image
-        image = '<img src="{}" '.format(uri)
-        if "alt" in attrs.keys():
-            image += 'alt="{}" '.format(attrs["alt"])
-        style = ""
-        if "width" in attrs.keys():
-            style += "width:{};".format(attrs["width"])
-        if "height" in attrs.keys():
-            style += "height:{};".format(attrs["height"])
-        if "scale" in attrs.keys():
-            style = "width:{0}%;height:{0}%".format(attrs["scale"])
-        image += 'style="{}" '.format(style)
-        if "align" in attrs.keys():
-            image += 'align="{}"'.format(attrs["align"])
-        image = image.rstrip() + ">\n\n"  #Add double space for html
-        #-Construct MD image
-        if return_markdown:
+        if self.jupyter_images_markdown:
+            #-Construct MD image
             image = "![{0}]({0})".format(uri)
+        else:
+            # Construct HTML image
+            image = '<img src="{}" '.format(uri)
+            if "alt" in attrs.keys():
+                image += 'alt="{}" '.format(attrs["alt"])
+            style = ""
+            if "width" in attrs.keys():
+                style += "width:{};".format(attrs["width"])
+            if "height" in attrs.keys():
+                style += "height:{};".format(attrs["height"])
+            if "scale" in attrs.keys():
+                style = "width:{0}%;height:{0}%".format(attrs["scale"])
+            image += 'style="{}" '.format(style)
+            if "align" in attrs.keys():
+                image += 'align="{}"'.format(attrs["align"])
+            image = image.rstrip() + ">\n\n"  #Add double space for html
         self.markdown_lines.append(image)
 
     # math

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -45,6 +45,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
         self.jupyter_images_urlpath = builder.config["jupyter_images_urlpath"]
+        self.jupyter_images_markdown = builder.config["jupyter_images_markdown"]
 
         # set the value of the cell metadata["slideshow"] to slide as the default option
         self.slide = "slide" 


### PR DESCRIPTION
This PR enables the option `jupyter_images_markdown` = `True` for writing image inclusion in text blocks in markdown, or `False` for writing in `html`. 

If this option is enabled it will remove support for `scale` attributes so the default value for this option is `False`. 