### PR TITLE
BUG: suppress yaml warnings for now, remove once dask is > 0.45

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -1,3 +1,6 @@
+import yaml
+yaml.warnings({'YAMLLoadWarning': False})
+
 from .builders.jupyter import JupyterBuilder
 from .directive.jupyter import jupyter_node
 from .directive.jupyter import Jupyter as JupyterDirective


### PR DESCRIPTION
Dask was throwing `yaml` errors on load. This suppresses them for now as fixed in dask (https://github.com/dask/dask/issues/4597)

fixes https://github.com/QuantEcon/sphinxcontrib-jupyter/issues/203