### PR TITLE
ENH: Added functionality to specify the dependencies in config

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -61,6 +61,7 @@ def setup(app):
     app.add_config_value("jupyter_make_coverage", False, "jupyter")
     app.add_config_value("jupyter_target_pdf", False, "jupyter")
     app.add_config_value("jupyter_coverage_dir", None, "jupyter")
+    app.add_config_value("jupyter_dependencies", None, "jupyter")
 
     # Jupyter Directive
     app.add_node(jupyter_node, html=(_noop, _noop), latex=(_noop, _noop))

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -14,6 +14,7 @@ from ..writers.convert import convertToHtmlWriter
 from dask.distributed import Client, progress
 from sphinx.util import logging
 import pdb
+from ..writers.utils import copy_dependencies
 
 class JupyterBuilder(Builder):
     """
@@ -176,6 +177,9 @@ class JupyterBuilder(Builder):
 
     def finish(self):
         self.finish_tasks.add_task(self.copy_static_files)
+
+		## copies the dependencies for notebooks
+        copy_dependencies(self)
 
         if (self.config["jupyter_execute_notebooks"]):
             # watch progress of the execution of futures

--- a/sphinxcontrib/jupyter/writers/execute_nb.py
+++ b/sphinxcontrib/jupyter/writers/execute_nb.py
@@ -7,6 +7,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from ..writers.convert import convertToHtmlWriter
 from sphinx.util import logging
 from dask.distributed import as_completed
+from ..writers.utils import copy_dependencies
 from io import open
 import sys
 
@@ -187,6 +188,9 @@ class ExecuteNotebookWriter():
                 update_count_delayed = 0
                 total_count += len(builderSelf.delayed_futures)
             builderSelf._execute_notebook_class.check_execution_completion(builderSelf, future, nb, error_results, count, total_count,  'delayed_futures')
+
+        ## copies the dependencies to the executed folder
+        copy_dependencies(builderSelf, builderSelf.executed_notebook_dir)
 
         return error_results
 

--- a/sphinxcontrib/jupyter/writers/utils.py
+++ b/sphinxcontrib/jupyter/writers/utils.py
@@ -3,7 +3,7 @@ import os
 import nbformat.v4
 from xml.etree.ElementTree import ElementTree
 from enum import Enum
-
+from shutil import copy
 
 class LanguageTranslator:
     """
@@ -137,3 +137,34 @@ def _str_to_lines(x):
         return list(map(lambda y: y.strip() + "\n", x.splitlines()))
 
     return x
+
+def copy_dependencies(builderSelf, outdir = None):
+    """
+    Copies the dependencies of source files or folders specified in the config to their respective output directories
+    """
+    if outdir is None:
+        outdir = builderSelf.outdir
+    else:
+        outdir = outdir
+    srcdir = builderSelf.srcdir
+    if 'jupyter_dependencies' in builderSelf.config and builderSelf.config['jupyter_dependencies'] is not None:
+        depenencyObj = builderSelf.config['jupyter_dependencies']
+        for key, deps in depenencyObj.items():
+            full_src_path = srcdir + "/" + key
+            if os.path.isdir(full_src_path):
+                ## handling the case of key being a directory
+                full_dest_path = outdir + "/" + key
+                for dep in deps:
+                    copy(full_src_path + "/" + dep, full_dest_path,follow_symlinks=True)
+            elif os.path.isfile(full_src_path):
+                ## handling the case of key being a file
+                # removing the filename to get the directory path
+                index = key.rfind('/')
+                if index!=0 and index != -1:
+                    key = key[0:index]
+                
+                full_src_path = srcdir + "/" + key
+                full_dest_path = outdir + "/" + key
+                for dep in deps:
+                    copy(full_src_path + "/" + dep, full_dest_path,follow_symlinks=True)
+


### PR DESCRIPTION
This PR adds the functionality to add dependencies of files and folders in the source directory in the following manner : 
```
jupyter_dependencies = {
    <dir> : ['file1', 'file2'],
    {<dir>}/<file.rst> : ['file1']
}
```

At present, the values are file names, which are assumed to be in the same directory as the source keys. 

fixes #228 