### PR TITLE
Fix julia build by checking lengh of `uri` string before accessing first element

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -825,7 +825,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
     @classmethod
     def add_extension_to_inline_link(cls, uri, ext):
         if "." not in uri:
-            if uri[0] == "#":
+            if len(uri) > 0 and uri[0] == "#":
                 return uri
             uri, id_ = cls.split_uri_id(uri)
             if len(id_) == 0:


### PR DESCRIPTION
This addresses #247

I believe we can always count on `uri` being a string and the `len` function being well defined for the type, but that is one vulnerability with this attempted fix.

