### PR TITLE
ENH: Setting jupyter_images_urlpath only for downloads folder

### DIFF
--- a/docs/config-example.rst
+++ b/docs/config-example.rst
@@ -148,7 +148,7 @@ The below configuration settings are the default ones provided by the
     jupyter_download_nb = False
 
     #Use urlprefix images
-    jupyter_images_urlpath = None
+    jupyter_download_nb_image_urlpath = None
 
     #Allow ipython as a language synonym for blocks to be ipython highlighted
     jupyter_lang_synonyms = ["ipython"]

--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -89,7 +89,7 @@ def setup(app):
     app.add_config_value("jupyter_target_html", False, "jupyter")
     app.add_config_value("jupyter_download_nb", False, "jupyter")
     app.add_config_value("jupyter_download_nb_urlpath", None, "jupyter")
-    app.add_config_value("jupyter_images_urlpath", None, "jupyter")
+    app.add_config_value("jupyter_download_nb_image_urlpath", None, "jupyter")
     app.add_config_value("jupyter_images_markdown", False, "jupyter")
 
     return {

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -114,7 +114,8 @@ class JupyterBuilder(Builder):
 
             outfilename = os.path.join(self.outdir + "/_downloads", os_path(docname) + self.out_suffix)
             ensuredir(os.path.dirname(outfilename))
-            self.writer._set_urlpath(self.config["jupyter_download_nb_urlpath"])
+            self.writer._set_ref_urlpath(self.config["jupyter_download_nb_urlpath"])
+            self.writer._set_jupyter_images_urlpath((self.config["jupyter_images_urlpath"]))
             self.writer.write(doctree, destination)
 
             try:
@@ -124,7 +125,8 @@ class JupyterBuilder(Builder):
                 self.warn("error writing file %s: %s" % (outfilename, err))
 
         ### output notebooks for executing
-        self.writer._set_urlpath(None)
+        self.writer._set_ref_urlpath(None)
+        self.writer._set_jupyter_images_urlpath(None)
         self.writer.write(doctree, destination)
 
         ### execute the notebook

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -115,7 +115,7 @@ class JupyterBuilder(Builder):
             outfilename = os.path.join(self.outdir + "/_downloads", os_path(docname) + self.out_suffix)
             ensuredir(os.path.dirname(outfilename))
             self.writer._set_ref_urlpath(self.config["jupyter_download_nb_urlpath"])
-            self.writer._set_jupyter_images_urlpath((self.config["jupyter_images_urlpath"]))
+            self.writer._set_jupyter_download_nb_image_urlpath((self.config["jupyter_download_nb_image_urlpath"]))
             self.writer.write(doctree, destination)
 
             try:
@@ -126,7 +126,7 @@ class JupyterBuilder(Builder):
 
         ### output notebooks for executing
         self.writer._set_ref_urlpath(None)
-        self.writer._set_jupyter_images_urlpath(None)
+        self.writer._set_jupyter_download_nb_image_urlpath(None)
         self.writer.write(doctree, destination)
 
         ### execute the notebook

--- a/sphinxcontrib/jupyter/writers/jupyter.py
+++ b/sphinxcontrib/jupyter/writers/jupyter.py
@@ -23,11 +23,17 @@ class JupyterWriter(docutils.writers.Writer):
         self.document.walkabout(visitor)
         self.output = nbformat.writes(visitor.output)
 
-    def _set_urlpath(self, urlpath=None):
+    def _set_ref_urlpath(self, urlpath=None):
         """
         Set a urlpath to be used to prepend links in the notebook, so that it can be different for different targets.
         """
         self.builder.urlpath = urlpath
+
+    def _set_jupyter_images_urlpath(self, urlpath=None):
+        """
+        Set a urlpath to be used to prepend image paths in the notebook, so that it can be different for different targets.
+        """
+        self.builder.jupyter_images_urlpath = urlpath
 
     def _identify_translator(self, builder):
         """

--- a/sphinxcontrib/jupyter/writers/jupyter.py
+++ b/sphinxcontrib/jupyter/writers/jupyter.py
@@ -29,11 +29,11 @@ class JupyterWriter(docutils.writers.Writer):
         """
         self.builder.urlpath = urlpath
 
-    def _set_jupyter_images_urlpath(self, urlpath=None):
+    def _set_jupyter_download_nb_image_urlpath(self, urlpath=None):
         """
         Set a urlpath to be used to prepend image paths in the notebook, so that it can be different for different targets.
         """
-        self.builder.jupyter_images_urlpath = urlpath
+        self.builder.jupyter_download_nb_image_urlpath = urlpath
 
     def _identify_translator(self, builder):
         """

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -175,10 +175,10 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         """
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
-        if self.jupyter_images_urlpath:
+        if self.jupyter_download_nb_image_urlpath:
             for file_path in self.jupyter_static_file_path:
                 if file_path in uri:
-                    uri = uri.replace(file_path +"/", self.jupyter_images_urlpath)
+                    uri = uri.replace(file_path +"/", self.jupyter_download_nb_image_urlpath)
                     break  #don't need to check other matches
         attrs = node.attributes
         if self.jupyter_images_markdown:

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -44,7 +44,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
-        self.jupyter_images_urlpath = builder.jupyter_images_urlpath
+        self.jupyter_download_nb_image_urlpath = builder.jupyter_download_nb_image_urlpath
         self.jupyter_images_markdown = builder.config["jupyter_images_markdown"]
         self.jupyter_target_pdf = builder.config["jupyter_target_pdf"]
 

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -44,7 +44,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
-        self.jupyter_images_urlpath = builder.config["jupyter_images_urlpath"]
+        self.jupyter_images_urlpath = builder.jupyter_images_urlpath
         self.jupyter_images_markdown = builder.config["jupyter_images_markdown"]
         self.jupyter_target_pdf = builder.config["jupyter_target_pdf"]
 

--- a/tests/website/conf.py
+++ b/tests/website/conf.py
@@ -243,7 +243,7 @@ jupyter_drop_tests = True
 jupyter_lang_synonyms = ["ipython", "python", "pycon"]
 
 # Image Prefix (enable web storage references)
-# jupyter_images_urlpath = "https://github.com/QuantEcon/sphinxcontrib-jupyter/raw/master/tests/_static/"
+# jupyter_download_nb_image_urlpath = "https://github.com/QuantEcon/sphinxcontrib-jupyter/raw/master/tests/_static/"
 jupyter_download_nb = False
 
 


### PR DESCRIPTION
The url set in `jupyter_images_urlpath` will only be prepended to download notebooks as of now. 

fixes #251 

@mmcky I have not renamed the variable though. Let me know if you come up with a name