### PR TITLE
Fix: slide fragment option not getting parsed correctly

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -752,7 +752,9 @@ class JupyterTranslator(JupyterCodeTranslator, object):
             if 'slide' in node.attributes:
                 self.metadata_slide = node['slide'] # this activates the slideshow metadata for the notebook
             if 'slide-type' in node.attributes:
-                self.slide = node['slide-type'] # replace the by default value
+                if "fragment" in node['slide-type']:
+                    self.add_markdown_cell(slide_type=node['slide-type'])   #start a new cell
+                self.slide = node['slide-type'] # replace the default value
         except:
             pass
         #Parse jupyter_dependency directive (TODO: Should this be a separate node type?)
@@ -767,10 +769,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         if 'slide' in node.attributes:
             pass
         if 'slide-type' in node.attributes:
-            if self.slide is "fragment":
-                self.add_markdown_cell()   #start a new cell
-
-
+            pass
 
     def visit_comment(self, node):
         raise nodes.SkipNode
@@ -800,7 +799,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
     # ================
     # general methods
     # ================
-    def add_markdown_cell(self):
+    def add_markdown_cell(self, slide_type="slide"):
         """split a markdown cell here
 
         * add the slideshow metadata
@@ -815,7 +814,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
             new_md_cell = nbformat.v4.new_markdown_cell(formatted_line_text)
             if self.metadata_slide:  # modify the slide metadata on each cell
                 new_md_cell.metadata["slideshow"] = slide_info
-                self.slide = "slide"  # set as the by default value
+                self.slide = slide_type
             self.output["cells"].append(new_md_cell)
             self.markdown_lines = []
 

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -767,7 +767,8 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         if 'slide' in node.attributes:
             pass
         if 'slide-type' in node.attributes:
-            pass
+            if self.slide is "fragment":
+                self.add_markdown_cell()   #start a new cell
 
 
 

--- a/tests/base/conf.py
+++ b/tests/base/conf.py
@@ -217,7 +217,7 @@ jupyter_drop_solutions = True
 jupyter_drop_tests = True
 
 # Add Ipython, Pycon and python as language synonyms
-jupyter_lang_synonyms = ["ipython", "python", "pycon"]
+jupyter_lang_synonyms = ["ipython", "python", "pycon", "ipython3"]
 
 exercise_include_exercises = True
 exercise_inline_exercises = True

--- a/tests/base/ipynb/index.ipynb
+++ b/tests/base/ipynb/index.ipynb
@@ -58,6 +58,7 @@
     "  - [Special Characters](simple_notebook.ipynb#special-characters)\n",
     "- [Slide option activated](slides.ipynb)\n",
     "  - [Math](slides.ipynb#math)\n",
+    "  - [Slide: Should have 2 code blocks as fragments (test)](slides.ipynb#slide-should-have-2-code-blocks-as-fragments-test)\n",
     "- [Notebook without solutions](solutions.ipynb)\n",
     "  - [Question 1](solutions.ipynb#question-1)\n",
     "- [Table](tables.ipynb)\n",

--- a/tests/base/ipynb/slides.ipynb
+++ b/tests/base/ipynb/slides.ipynb
@@ -104,34 +104,34 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "hide-output": false,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
-   "outputs": [],
    "source": [
+    "```ipython3\n",
     "# This code block should be a Fragment!\n",
     "fibonacci_functional = (lambda n, first=1, second=1:\n",
     "    [] if n == 0 else\n",
-    "    [first] + fibonacci_functional(n - 1, second, first + second))"
+    "    [first] + fibonacci_functional(n - 1, second, first + second))\n",
+    "```\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "hide-output": false,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
-   "outputs": [],
    "source": [
-    "for k in fibonacci_functional(10):print(k,end=' ')"
+    "```ipython3\n",
+    "for k in fibonacci_functional(10):print(k,end=' ')\n",
+    "```\n"
    ]
   }
  ],

--- a/tests/base/ipynb/slides.ipynb
+++ b/tests/base/ipynb/slides.ipynb
@@ -104,34 +104,34 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "hide-output": false,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
+   "outputs": [],
    "source": [
-    "```ipython3\n",
     "# This code block should be a Fragment!\n",
     "fibonacci_functional = (lambda n, first=1, second=1:\n",
     "    [] if n == 0 else\n",
-    "    [first] + fibonacci_functional(n - 1, second, first + second))\n",
-    "```\n"
+    "    [first] + fibonacci_functional(n - 1, second, first + second))"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "hide-output": false,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
+   "outputs": [],
    "source": [
-    "```ipython3\n",
-    "for k in fibonacci_functional(10):print(k,end=' ')\n",
-    "```\n"
+    "for k in fibonacci_functional(10):print(k,end=' ')"
    ]
   }
  ],

--- a/tests/base/ipynb/slides.ipynb
+++ b/tests/base/ipynb/slides.ipynb
@@ -28,6 +28,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "hide-output": false,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -46,6 +47,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "hide-output": false,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -88,6 +90,48 @@
     "We can also include the figures from some folder\n",
     "\n",
     "<img src=\"_static/hood.jpg\" style=\"\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Slide: Should have 2 code blocks as fragments (test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide-output": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# This code block should be a Fragment!\n",
+    "fibonacci_functional = (lambda n, first=1, second=1:\n",
+    "    [] if n == 0 else\n",
+    "    [first] + fibonacci_functional(n - 1, second, first + second))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide-output": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for k in fibonacci_functional(10):print(k,end=' ')"
    ]
   }
  ],

--- a/tests/base/slides.rst
+++ b/tests/base/slides.rst
@@ -60,7 +60,7 @@ Slide: Should have 2 code blocks as fragments (test)
 .. jupyter::
     :slide-type: fragment
 
-.. code:: ipython3
+.. code-block:: ipython3
 
     # This code block should be a Fragment!
     fibonacci_functional = (lambda n, first=1, second=1:
@@ -70,6 +70,6 @@ Slide: Should have 2 code blocks as fragments (test)
 .. jupyter::
     :slide-type: fragment
 
-.. code:: ipython3
+.. code-block:: ipython3
 
     for k in fibonacci_functional(10):print(k,end=' ')

--- a/tests/base/slides.rst
+++ b/tests/base/slides.rst
@@ -52,3 +52,24 @@ We can also include the figures from some folder
 
 
 .. figure:: _static/hood.jpg
+
+
+Slide: Should have 2 code blocks as fragments (test)
+++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. jupyter::
+    :slide-type: fragment
+
+.. code:: ipython3
+
+    # This code block should be a Fragment!
+    fibonacci_functional = (lambda n, first=1, second=1:
+        [] if n == 0 else
+        [first] + fibonacci_functional(n - 1, second, first + second))
+
+.. jupyter::
+    :slide-type: fragment
+
+.. code:: ipython3
+
+    for k in fibonacci_functional(10):print(k,end=' ')


### PR DESCRIPTION
This PR fixes bug #226 

The following `RST`

```RST
Slide: Should have 2 code blocks as fragments (test)
++++++++++++++++++++++++++++++++++++++++++++++++++++

.. jupyter::
    :slide-type: fragment

.. code:: ipython3

    # This code block should be a Fragment!
    fibonacci_functional = (lambda n, first=1, second=1:
        [] if n == 0 else
        [first] + fibonacci_functional(n - 1, second, first + second))

.. jupyter::
    :slide-type: fragment

.. code:: ipython3

    for k in fibonacci_functional(10):print(k,end=' ')
```

is now rendered as

![image](https://user-images.githubusercontent.com/8263752/63407859-fdf9ed80-c430-11e9-9902-63ed9e7d0580.png)

in `tests/base/slides.rst`