### PR TITLE
Remove egg cfg to remove dev status on version releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[egg_info]
-tag_build = dev
-tag_date = true
-
-[aliases]
-release = egg_info -RDb ''


### PR DESCRIPTION
This PR adjusts versions to follow the main version in `setup.py` and doesn't append `dev{date}` to the builds. 