### PR TITLE
TEST: add :class: attribute test for literalinclude

### DIFF
--- a/tests/base/ipynb/literal_include.ipynb
+++ b/tests/base/ipynb/literal_include.ipynb
@@ -12,7 +12,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "hide-output": false
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -29,7 +31,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "hide-output": false
+   },
    "source": [
     "```julia\n",
     "# function to calculate the volume of a sphere\n",
@@ -45,7 +49,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "this is a julia highlighted program but is in a markdown cell as the default language for the notebook is **python**"
+    "this is a julia highlighted program but is in a markdown cell as the default language for the notebook is **python**\n",
+    "\n",
+    "Literal includes can also have hidden output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide-output": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "a = np.random.rand(1000)\n",
+    "print(a)"
    ]
   }
  ],

--- a/tests/base/literal_include.rst
+++ b/tests/base/literal_include.rst
@@ -11,3 +11,8 @@ should list a python highlighted program
    :language: julia
 
 this is a julia highlighted program but is in a markdown cell as the default language for the notebook is **python**
+
+Literal includes can also have hidden output
+
+.. literalinclude:: ./simple_program.py
+   :class: hide-output


### PR DESCRIPTION
This PR adds a test case to `base` set of notebook tests for class attributes on ``.. literalinclude::``