### PR TITLE
ENH: adjust uri to use provided source folders for `jupyter_download_nb`

### DIFF
--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -175,7 +175,7 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         """
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
-        if self.jupyter_download_nb and self.jupyter_download_nb_image_urlpath:
+        if self.jupyter_download_nb_image_urlpath:
             for file_path in self.jupyter_static_file_path:
                 #Adjust Relative References
                 if "../" in uri:

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -183,9 +183,11 @@ class JupyterTranslator(JupyterCodeTranslator, object):
                 #If the root path "/" is specified in RST URI then only the name of the source directory will be needed for substitution
                 if "/" in file_path and uri.split("/")[0] == file_path.split("/")[-1]:
                     uri = uri.replace(file_path.split("/")[-1]+"/", self.jupyter_download_nb_image_urlpath)
+                    break
                 #Otherwise full file_path needs to be replaced
                 else:
                     uri = uri.replace(file_path+"/", self.jupyter_download_nb_image_urlpath)
+                    break
         attrs = node.attributes
         if self.jupyter_images_markdown:
             #-Construct MD image

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -186,7 +186,6 @@ class JupyterTranslator(JupyterCodeTranslator, object):
                 #Otherwise full file_path needs to be replaced
                 else:
                     uri = uri.replace(file_path+"/", self.jupyter_download_nb_image_urlpath)
-                import pdb; pdb.set_trace()
         attrs = node.attributes
         if self.jupyter_images_markdown:
             #-Construct MD image

--- a/sphinxcontrib/jupyter/writers/translate_all.py
+++ b/sphinxcontrib/jupyter/writers/translate_all.py
@@ -175,11 +175,18 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         """
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
-        if self.jupyter_download_nb_image_urlpath:
+        if self.jupyter_download_nb and self.jupyter_download_nb_image_urlpath:
             for file_path in self.jupyter_static_file_path:
-                if file_path in uri:
-                    uri = uri.replace(file_path +"/", self.jupyter_download_nb_image_urlpath)
-                    break  #don't need to check other matches
+                #Adjust Relative References
+                if "../" in uri:
+                    uri = uri.replace("../","")
+                #If the root path "/" is specified in RST URI then only the name of the source directory will be needed for substitution
+                if "/" in file_path and uri.split("/")[0] == file_path.split("/")[-1]:
+                    uri = uri.replace(file_path.split("/")[-1]+"/", self.jupyter_download_nb_image_urlpath)
+                #Otherwise full file_path needs to be replaced
+                else:
+                    uri = uri.replace(file_path+"/", self.jupyter_download_nb_image_urlpath)
+                import pdb; pdb.set_trace()
         attrs = node.attributes
         if self.jupyter_images_markdown:
             #-Construct MD image

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -44,7 +44,8 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
-        self.jupyter_download_nb_image_urlpath = builder.jupyter_download_nb_image_urlpath
+        self.jupyter_download_nb = builder.config["jupyter_download_nb"]
+        self.jupyter_download_nb_image_urlpath = builder.config["jupyter_download_nb_image_urlpath"]
         self.jupyter_images_markdown = builder.config["jupyter_images_markdown"]
         self.jupyter_target_pdf = builder.config["jupyter_target_pdf"]
 

--- a/sphinxcontrib/jupyter/writers/translate_code.py
+++ b/sphinxcontrib/jupyter/writers/translate_code.py
@@ -44,10 +44,11 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.jupyter_ignore_skip_test = builder.config["jupyter_ignore_skip_test"]
         self.jupyter_lang_synonyms = builder.config["jupyter_lang_synonyms"]
         self.jupyter_target_html = builder.config["jupyter_target_html"]
-        self.jupyter_download_nb = builder.config["jupyter_download_nb"]
-        self.jupyter_download_nb_image_urlpath = builder.config["jupyter_download_nb_image_urlpath"]
         self.jupyter_images_markdown = builder.config["jupyter_images_markdown"]
         self.jupyter_target_pdf = builder.config["jupyter_target_pdf"]
+
+        # Non global variables set in builder
+        self.jupyter_download_nb_image_urlpath = builder.jupyter_download_nb_image_urlpath
 
         # set the value of the cell metadata["slideshow"] to slide as the default option
         self.slide = "slide" 


### PR DESCRIPTION
This PR adjusts the `URI` when using the `jupyter_download_nb_image_urlpath` to use `_static` paths adjusted for `/` and relative `../` conditions without having to specify incorrect paths in `conf.py` option `jupyter_static_file_path` 