### PR TITLE
TEST: add test cases for escape syntax

### DIFF
--- a/tests/base/ipynb/syntax.ipynb
+++ b/tests/base/ipynb/syntax.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Syntax\n",
+    "\n",
+    "This contains test cases for using special syntax\n",
+    "\n",
+    "If we use `%` in text:\n",
+    "\n",
+    "15%\n",
+    "\n",
+    "and with `\\%`\n",
+    "\n",
+    "15%\n",
+    "\n",
+    "IF we use `#` in text:\n",
+    "\n",
+    "#1\n",
+    "\n",
+    "and with `\\#`\n",
+    "\n",
+    "#1\n",
+    "\n",
+    "If we use `\\$` in text:\n",
+    "\n",
+    "\\$100,000\n",
+    "\n",
+    "and with `\\\\$`\n",
+    "\n",
+    "\\$100,000"
+   ]
+  }
+ ],
+ "metadata": {
+  "date": 1574991173.427386,
+  "filename": "syntax.rst",
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python3",
+   "name": "python3"
+  },
+  "title": "Syntax"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/base/syntax.rst
+++ b/tests/base/syntax.rst
@@ -1,0 +1,29 @@
+Syntax
+=======
+
+This contains test cases for using special syntax
+
+If we use ``%`` in text:
+
+15%
+
+and with ``\%``
+
+15\%
+
+IF we use ``#`` in text:
+
+#1
+
+and with ``\#``
+
+\#1
+
+If we use ``$`` in text:
+
+$100,000
+
+and with ``\$``
+
+\$100,000
+


### PR DESCRIPTION
This tests `$` vs `\$` in the source RST