### PR TITLE
 Fixing versions of dask to prevent code syntax issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['docutils', 'nbformat', 'sphinx', 'dask==2.10.0', 'dask[distributed]==2.10.0', 'ipython', 'nbconvert', 'jupyter_client'],
+    install_requires=['docutils', 'nbformat', 'sphinx', 'dask', 'dask[distributed]', 'ipython', 'nbconvert', 'jupyter_client'],
     namespace_packages=['sphinxcontrib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['docutils', 'nbformat', 'sphinx', 'dask', 'dask[distributed]', 'ipython', 'nbconvert', 'jupyter_client'],
+    install_requires=['docutils', 'nbformat', 'sphinx', 'dask==2.10.1', 'dask[distributed]==2.10.0', 'ipython', 'nbconvert', 'jupyter_client'],
     namespace_packages=['sphinxcontrib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = 'v0.5.2'
+VERSION = 'v0.5.3'
 
 LONG_DESCRIPTION = """
 This package contains a `Sphinx <http://www.sphinx-doc.org/en/master/>`_ extension 
@@ -67,6 +67,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['docutils', 'nbformat', 'sphinx', 'dask==2.10.1', 'dask[distributed]==2.10.0', 'ipython', 'nbconvert', 'jupyter_client'],
+    install_requires=['docutils', 'nbformat', 'sphinx', 'dask==2.10.0', 'dask[distributed]==2.10.0', 'ipython', 'nbconvert', 'jupyter_client'],
     namespace_packages=['sphinxcontrib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = 'v0.5.3'
+VERSION = 'v0.5.2'
 
 LONG_DESCRIPTION = """
 This package contains a `Sphinx <http://www.sphinx-doc.org/en/master/>`_ extension 

--- a/sphinxcontrib/jupyter/writers/execute_nb.py
+++ b/sphinxcontrib/jupyter/writers/execute_nb.py
@@ -122,7 +122,7 @@ class ExecuteNotebookWriter():
         ## calculates execution time of each task in client using get task stream
         task_Info_latest = builderSelf.client.get_task_stream()[-1]
         time_tuple = task_Info_latest['startstops'][0]
-        computing_time = time_tuple[2] - time_tuple[1]
+        computing_time = time_tuple['stop'] - time_tuple['start']
         return computing_time
 
     def check_execution_completion(self, builderSelf, future, nb, error_results, count, total_count, futures_name, params):

--- a/sphinxcontrib/jupyter/writers/execute_nb.py
+++ b/sphinxcontrib/jupyter/writers/execute_nb.py
@@ -7,6 +7,7 @@ import json
 from nbconvert.preprocessors import ExecutePreprocessor
 from ..writers.convert import convertToHtmlWriter
 from sphinx.util import logging
+import dask
 from dask.distributed import as_completed
 from packaging import version
 from io import open

--- a/sphinxcontrib/jupyter/writers/execute_nb.py
+++ b/sphinxcontrib/jupyter/writers/execute_nb.py
@@ -8,6 +8,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from ..writers.convert import convertToHtmlWriter
 from sphinx.util import logging
 from dask.distributed import as_completed
+from packaging import version
 from io import open
 import sys
 
@@ -122,7 +123,11 @@ class ExecuteNotebookWriter():
         ## calculates execution time of each task in client using get task stream
         task_Info_latest = builderSelf.client.get_task_stream()[-1]
         time_tuple = task_Info_latest['startstops'][0]
-        computing_time = time_tuple['stop'] - time_tuple['start']
+
+        if version.parse(dask.__version__) <  version.parse("2.10.0"):
+            computing_time = time_tuple[2] - time_tuple[1]
+        else:
+            computing_time = time_tuple['stop'] - time_tuple['start']
         return computing_time
 
     def check_execution_completion(self, builderSelf, future, nb, error_results, count, total_count, futures_name, params):


### PR DESCRIPTION
Dask less then `2.10` uses a different data structure for `startstops` in `get_task_stream` then the newer version.