### PR TITLE
Throwing an exit code of 1 when there is an error in coverage

### DIFF
--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -45,6 +45,7 @@ class JupyterBuilder(Builder):
         self.downloadsdir = self.outdir + "/_downloads"
         self.downloadsExecutedir = self.downloadsdir + "/executed"
         self.client = None
+        self.execution_status_code = 0
 
         # Check default language is defined in the jupyter kernels
         def_lng = self.config["jupyter_default_lang"]
@@ -263,3 +264,5 @@ class JupyterBuilder(Builder):
                 error_results  = self._execute_notebook_class.produce_code_execution_report(self, error_results, params)
 
                 self._execute_notebook_class.create_coverage_report(self, error_results, params)
+            
+            exit(self.execution_status_code)

--- a/sphinxcontrib/jupyter/writers/execute_nb.py
+++ b/sphinxcontrib/jupyter/writers/execute_nb.py
@@ -91,7 +91,6 @@ class ExecuteNotebookWriter():
 
         ## ensure that executed notebook directory
         ensuredir(builderSelf.executed_notebook_dir)
-
         ## specifying kernels
         if language == 'python':
             if (sys.version_info > (3, 0)):
@@ -136,6 +135,11 @@ class ExecuteNotebookWriter():
         # store the exceptions in an error result array
         if future.status == 'error':
             status = 'fail'
+            try:
+                builderSelf.execution_status_code = 1
+            except:
+                self.logger.warning("No execution status code defined in builder")
+
             for key,val in builderSelf.futuresInfo.items():
                 if key == future.key:
                     filename_with_path = val['filename_with_path']


### PR DESCRIPTION
Throws an exit code of 1 when there is a `fail` status for any lecture during the execution of its code cells.