### PR TITLE
update version to 0.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,13 @@
 sudo: false        #Use new Container Infrastructure
 language: python
 python:
-  - 2.7
   - 3.7
+  - 3.8
 
 env:
   - SPHINX_VERSION=1.7.9
   - SPHINX_VERSION=1.8.5
   - SPHINX_VERSION=2.1.2
-
-matrix:
-  exclude:
-  - python: 2.7
-    env: SPHINX_VERSION=2.1.2
 
 directories:
   - "/tmp/texlive"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = 'v0.5.4'
+VERSION = 'v0.5.5'
 
 LONG_DESCRIPTION = """
 This package contains a `Sphinx <http://www.sphinx-doc.org/en/master/>`_ extension 


### PR DESCRIPTION
This PR update version to 0.5.5 for new release, removes testing for `python=2.7`, and adds testing for `python=3.8`