### PR TITLE
Remove early version requirements for dask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
       pip install sphinx==$SPHINX_VERSION nbconvert nbformat dask distributed nbdime;
       pip install sphinxcontrib-bibtex==0.4.2;
     else
-      pip install sphinx==$SPHINX_VERSION nbconvert nbformat dask==2.5.2 distributed==2.5.2 nbdime;
+      pip install sphinx==$SPHINX_VERSION nbconvert nbformat dask distributed nbdime;
       pip install sphinxcontrib-bibtex;
     fi
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['docutils', 'nbformat', 'sphinx', 'dask<=2.5.2', 'distributed<=2.5.2', 'ipython', 'nbconvert', 'jupyter_client'],
+    install_requires=['docutils', 'nbformat', 'sphinx', 'dask', 'distributed', 'ipython', 'nbconvert', 'jupyter_client'],
     namespace_packages=['sphinxcontrib'],
 )


### PR DESCRIPTION
This PR removes the early version restrictions for `dask` in the `setup.py` due to https://github.com/QuantEcon/sphinxcontrib-jupyter/pull/314/files
 
