### PR TITLE
ENH: Add support for exclusion of Next and Previous metadata in conf.py

### DIFF
--- a/sphinxcontrib/jupyter/__init__.py
+++ b/sphinxcontrib/jupyter/__init__.py
@@ -71,6 +71,7 @@ def setup(app):
     app.add_config_value("jupyter_template_path", "templates", "jupyter")
     app.add_config_value("jupyter_dependencies", None, "jupyter")
     app.add_config_value("jupyter_download_nb_execute", None, "jupyter")
+    app.add_config_value("jupyter_nextprev_ignore", [], "jupyter")
 
     # Jupyter pdf options
     app.add_config_value("jupyter_latex_template", None, "jupyter")

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -215,20 +215,32 @@ class JupyterBuilder(Builder):
             titles = self.env.titles
             if related and related[2]:
                 try:
-                    next_doc = {
-                        'link': self.get_relative_uri(docname, related[2]),
-                        'title': titles[related[2]].children[0].astext()
-                    }
-                    nb.metadata.next_doc = next_doc
+                    link = self.get_relative_uri(docname, related[2])
+                    title = titles[related[2]].children[0].astext()
+                    # link is document uri (i.e. docname) as specified in index
+                    if link in self.config.jupyter_nextprev_ignore:
+                        pass
+                    else:
+                        next_doc = {
+                            'link': link,
+                            'title': title
+                        }
+                        nb.metadata.next_doc = next_doc
                 except KeyError:
                     nb.metadata.next_doc = False
             if related and related[1]:
                 try:
-                    prev_doc = {
-                        'link': self.get_relative_uri(docname, related[1]),
-                        'title': titles[related[1]].children[0].astext()
-                    }
-                    nb.metadata.prev_doc = prev_doc
+                    link = self.get_relative_uri(docname, related[1])
+                    title = titles[related[1]].children[0].astext()
+                    # link is document uri (i.e. docname) as specified in index
+                    if link in self.config.jupyter_nextprev_ignore:
+                        pass
+                    else:
+                        prev_doc = {
+                            'link': link,
+                            'title': title
+                        }
+                        nb.metadata.prev_doc = prev_doc
                 except KeyError:
                     nb.metadata.prev_doc = False
         # Set Compile Datetime


### PR DESCRIPTION
This PR adds support for next and prev metadata to exclude items, such as hidden TOC elements. 

You can add in `conf.py`

```rst
jupyter_nextprev_ignore = [<docname>, ...]
```