### PR TITLE
FIX: fix bug with mixed titles having many children for next and prev metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = 'v0.5.8'
+VERSION = 'v0.5.8b'
 
 LONG_DESCRIPTION = """
 This package contains a `Sphinx <http://www.sphinx-doc.org/en/master/>`_ extension 

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -1,6 +1,7 @@
 import codecs
 import os.path
 import docutils.io
+import docutils
 
 import nbformat
 from sphinx.util.osutil import ensuredir, os_path
@@ -216,7 +217,13 @@ class JupyterBuilder(Builder):
             if related and related[2]:
                 try:
                     link = self.get_relative_uri(docname, related[2])
-                    title = titles[related[2]].children[0].astext()
+                    title_relation = titles[related[2]]
+                    # Filter out non-text elements like index entries
+                    if len(title_relation.children) > 1:
+                        text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
+                        title = "".join([item.astext() for item in text_nodes])
+                    else:
+                        title = title_relation.children[0].astext()
                     # link is document uri (i.e. docname) as specified in index
                     if link in self.config.jupyter_nextprev_ignore:
                         pass
@@ -231,7 +238,13 @@ class JupyterBuilder(Builder):
             if related and related[1]:
                 try:
                     link = self.get_relative_uri(docname, related[1])
-                    title = titles[related[1]].children[0].astext()
+                    title_relation = titles[related[2]]
+                    # Filter out non-text elements like index entries
+                    if len(title_relation.children) > 1:
+                        text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
+                        title = "".join([item.astext() for item in text_nodes])
+                    else:
+                        title = title_relation.children[0].astext()
                     # link is document uri (i.e. docname) as specified in index
                     if link in self.config.jupyter_nextprev_ignore:
                         pass


### PR DESCRIPTION
This PR fixes a bug where inline elements in a title can break the title name metadata stored in the notebook when the builder parses titles for `next` and `prev` metadata. 