### PR TITLE
FIX: Simply interface with template layer for next and prev metadata in notebooks

### DIFF
--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -217,17 +217,18 @@ class JupyterBuilder(Builder):
             if related and related[2]:
                 try:
                     link = self.get_relative_uri(docname, related[2])
-                    title_relation = titles[related[2]]
-                    # Filter out non-text elements like index entries
-                    if len(title_relation.children) > 1:
-                        text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
-                        title = "".join([item.astext() for item in text_nodes])
-                    else:
-                        title = title_relation.children[0].astext()
                     # link is document uri (i.e. docname) as specified in index
                     if link in self.config.jupyter_nextprev_ignore:
                         pass
                     else:
+                        title_relation = titles[related[2]]
+                        # Filter out non-text elements like index entries
+                        if len(title_relation.children) > 1:
+                            text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
+                            title = "".join([item.astext() for item in text_nodes])
+                        else:
+                            title = title_relation.children[0].astext()
+                        # Set next_doc metadata
                         next_doc = {
                             'link': link,
                             'title': title
@@ -240,17 +241,18 @@ class JupyterBuilder(Builder):
             if related and related[1]:
                 try:
                     link = self.get_relative_uri(docname, related[1])
-                    title_relation = titles[related[2]]
-                    # Filter out non-text elements like index entries
-                    if len(title_relation.children) > 1:
-                        text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
-                        title = "".join([item.astext() for item in text_nodes])
-                    else:
-                        title = title_relation.children[0].astext()
                     # link is document uri (i.e. docname) as specified in index
                     if link in self.config.jupyter_nextprev_ignore:
                         pass
                     else:
+                        title_relation = titles[related[1]]
+                        # Filter out non-text elements like index entries
+                        if len(title_relation.children) > 1:
+                            text_nodes = [item for item in title_relation if isinstance(item, docutils.nodes.Text)]
+                            title = "".join([item.astext() for item in text_nodes])
+                        else:
+                            title = title_relation.children[0].astext()
+                        # Set prev_doc metadata
                         prev_doc = {
                             'link': link,
                             'title': title

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -234,7 +234,7 @@ class JupyterBuilder(Builder):
                         }
                         nb.metadata.next_doc = next_doc
                 except KeyError:
-                    nb.metadata.next_doc = False
+                    pass
             if related and related[1]:
                 try:
                     link = self.get_relative_uri(docname, related[1])
@@ -255,7 +255,7 @@ class JupyterBuilder(Builder):
                         }
                         nb.metadata.prev_doc = prev_doc
                 except KeyError:
-                    nb.metadata.prev_doc = False
+                    pass
         # Set Compile Datetime
         nb.metadata.date = time.time()
         return nb

--- a/sphinxcontrib/jupyter/builders/jupyter.py
+++ b/sphinxcontrib/jupyter/builders/jupyter.py
@@ -234,7 +234,9 @@ class JupyterBuilder(Builder):
                         }
                         nb.metadata.next_doc = next_doc
                 except KeyError:
-                    pass
+                    self.logger.warning(
+                        "[NB Metadata] No next_doc relation is found for: {}"
+                        .format(docname))
             if related and related[1]:
                 try:
                     link = self.get_relative_uri(docname, related[1])
@@ -255,7 +257,9 @@ class JupyterBuilder(Builder):
                         }
                         nb.metadata.prev_doc = prev_doc
                 except KeyError:
-                    pass
+                    self.logger.warning(
+                        "[NB Metadata] No prev_doc relation is found for: {}"
+                        .format(docname))
         # Set Compile Datetime
         nb.metadata.date = time.time()
         return nb


### PR DESCRIPTION
This PR simplifies the metadata added to notebooks by not including metadata if a relation is not found in the notebook